### PR TITLE
Implement new texture format support, decoding fixes, and linearizati…

### DIFF
--- a/ReLunacy.Engine/Assets/Interfaces/ITexture.cs
+++ b/ReLunacy.Engine/Assets/Interfaces/ITexture.cs
@@ -7,7 +7,14 @@ public enum TextureFormat
     A8R8G8B8 = 2,
     DXT1 = 3,
     DXT3 = 4,
-    DXT5 = 5
+    DXT5 = 5,
+    R8 = 6,
+    A1R5G5B5 = 7,
+    BC4 = 8,
+    BC5 = 9,
+    G8B8 = 10,
+    RGBA4 = 11,
+    RGBA16F = 12,
 }
 
 public interface ITexture : IAsset

--- a/ReLunacy.Engine/Assets/Textures/Texture.cs
+++ b/ReLunacy.Engine/Assets/Textures/Texture.cs
@@ -71,10 +71,12 @@ public sealed class Texture : ITexture
     {
         return format switch
         {
-            TextureFormat.R5G6B5 => width * height * 2,
+            TextureFormat.R5G6B5 or TextureFormat.A1R5G5B5 or TextureFormat.G8B8 or TextureFormat.RGBA4 => width * height * 2,
             TextureFormat.A8R8G8B8 => width * height * 4,
-            TextureFormat.DXT1 => Math.Max(1, (width + 3) / 4) * Math.Max(1, (height + 3) / 4) * 8,
-            TextureFormat.DXT3 or TextureFormat.DXT5 => Math.Max(1, (width + 3) / 4) * Math.Max(1, (height + 3) / 4) * 16,
+            TextureFormat.RGBA16F => width * height * 8,
+            TextureFormat.R8 => width * height,
+            TextureFormat.DXT1 or TextureFormat.BC4 => Math.Max(1, (width + 3) / 4) * Math.Max(1, (height + 3) / 4) * 8,
+            TextureFormat.DXT3 or TextureFormat.DXT5 or TextureFormat.BC5 => Math.Max(1, (width + 3) / 4) * Math.Max(1, (height + 3) / 4) * 16,
             _ => throw new NotSupportedException($"Format {format} not supported")
         };
     }

--- a/ReLunacy.Engine/Loading/Interfaces/ITextureMetadata.cs
+++ b/ReLunacy.Engine/Loading/Interfaces/ITextureMetadata.cs
@@ -8,4 +8,10 @@ public interface ITextureMetadata
     public uint Height { get; }
     public TextureFormat Format { get; }
     public ushort MipmapCount { get; }
+
+    /// <summary>True if this texture's pixel data is stored linearly (not Morton-swizzled). Always
+    /// true for block-compressed formats (DXT/BC) regardless of any per-instance flag. Otherwise
+    /// per-instance: old engine reads it from a bit in formatBitfield, new engine derives it from
+    /// the raw format byte's 0x8X (swizzled) / 0xAX (linear) prefix — see TextureMetadataOld/New.</summary>
+    public bool IsLinear { get; }
 }

--- a/ReLunacy.Engine/Loading/Readers/DebugReader.cs
+++ b/ReLunacy.Engine/Loading/Readers/DebugReader.cs
@@ -14,7 +14,11 @@ public sealed class DebugReader
     // names from gp_prius.dat (mobys) or the zone's own file (ties), not debug.dat.
     private readonly List<string?> _mobyInstanceNames = [];
     private readonly List<string?> _tieInstanceNames = [];
-    private readonly List<string> _volumeNames = [];
+    // Index-aligned with the old-engine volume transform array (section 0x7740 in gameplay.dat —
+    // see RegionReader.ReadVolumesOld), same as _mobyInstanceNames/_tieInstanceNames above. Must
+    // stay List<string?> with an unconditional Add per entry, not List<string> skipping empties —
+    // skipping any entry desyncs every name after it from its actual volume index.
+    private readonly List<string?> _volumeNames = [];
     private readonly bool _isOld;
 
     public DebugReader(FileManager fileManager)
@@ -133,12 +137,16 @@ public sealed class DebugReader
         var section = _debugFile!.QuerySection(0x7760);
         if (section.count == 0) return;
 
-        for (int i = 0; i < section.count; i++)
-        {
-            var volumeName = _debugFile.sh.ReadString();
-            if (!string.IsNullOrEmpty(volumeName))
-                _volumeNames.Add(volumeName);
-        }
+        // Previously read via a bare loop of sh.ReadString() calls with no seek to section.offset
+        // first — it read from wherever the stream happened to be left by LoadShaderNames() just
+        // before it, not this section's actual data, and skipped adding an entry at all for empty
+        // names instead of preserving the slot — desyncing every name after the first gap from its
+        // real volume index. Same struct/pattern as moby/tie instance names fixes both.
+        _debugFile.sh.Seek(section.offset);
+        var names = FileUtils.ReadStructureArray<DebugInstanceName>(_debugFile.sh, section.count);
+
+        foreach (var item in names)
+            _volumeNames.Add(string.IsNullOrEmpty(item.name) ? null : item.name);
     }
 
     public string? GetMobyPrototypeName(ulong tuid) => _mobyPrototypeNames.TryGetValue(tuid, out var name) ? name : null;
@@ -146,6 +154,7 @@ public sealed class DebugReader
     public string? GetShaderName(ulong tuid) => _shaderNames.TryGetValue(tuid, out var name) ? name : null;
     public string? GetMobyInstanceName(int index) => index >= 0 && index < _mobyInstanceNames.Count ? _mobyInstanceNames[index] : null;
     public string? GetTieInstanceName(int index) => index >= 0 && index < _tieInstanceNames.Count ? _tieInstanceNames[index] : null;
+    public string? GetVolumeName(int index) => index >= 0 && index < _volumeNames.Count ? _volumeNames[index] : null;
 
     public string GetSummary()
     {

--- a/ReLunacy.Engine/Loading/Readers/MaterialReader.cs
+++ b/ReLunacy.Engine/Loading/Readers/MaterialReader.cs
@@ -160,8 +160,12 @@ public sealed class MaterialReader
     private static bool UsesVertexAlphaCandidate(RenderingMode mode, ITexture? albedo) =>
         mode is RenderingMode.Overlay or RenderingMode.SoftEdge or RenderingMode.Blended && !HasAlphaChannel(albedo);
 
+    // A1R5G5B5/RGBA4 carry real (if low-precision) alpha bits, same as A8R8G8B8/DXT3/DXT5 —
+    // included here for the same reason those are: UsesVertexAlphaCandidate should only kick in
+    // when the albedo genuinely has nowhere else to source transparency from.
     private static bool HasAlphaChannel(ITexture? texture) =>
-        texture?.Format is TextureFormat.A8R8G8B8 or TextureFormat.DXT3 or TextureFormat.DXT5;
+        texture?.Format is TextureFormat.A8R8G8B8 or TextureFormat.DXT3 or TextureFormat.DXT5
+            or TextureFormat.A1R5G5B5 or TextureFormat.RGBA4;
 
     private static TextureFormat ToTextureFormat(Textures.TextureFormat format) => format switch
     {
@@ -170,6 +174,13 @@ public sealed class MaterialReader
         Textures.TextureFormat.DXT1 => TextureFormat.DXT1,
         Textures.TextureFormat.DXT3 => TextureFormat.DXT3,
         Textures.TextureFormat.DXT5 => TextureFormat.DXT5,
+        Textures.TextureFormat.R8 => TextureFormat.R8,
+        Textures.TextureFormat.A1R5G5B5 => TextureFormat.A1R5G5B5,
+        Textures.TextureFormat.BC4 => TextureFormat.BC4,
+        Textures.TextureFormat.BC5 => TextureFormat.BC5,
+        Textures.TextureFormat.G8B8 => TextureFormat.G8B8,
+        Textures.TextureFormat.RGBA4 => TextureFormat.RGBA4,
+        Textures.TextureFormat.RGBA16F => TextureFormat.RGBA16F,
         _ => TextureFormat.Unknown,
     };
 }

--- a/ReLunacy.Engine/Loading/Readers/RegionReader.cs
+++ b/ReLunacy.Engine/Loading/Readers/RegionReader.cs
@@ -31,7 +31,7 @@ public sealed class RegionReader
         IGFile gameplayFile = _fileManager.igfiles["gameplay.dat"]!;
 
         var mobyInstances = ReadMobyInstancesOld(gameplayFile);
-        var volumes = ReadVolumesOld(gameplayFile);
+        var volumes = ReadVolumesOld(gameplayFile, _debugReader);
 
         return new Assets.Levels.Region(
             id: 0,
@@ -235,14 +235,26 @@ public sealed class RegionReader
         sh.ReadSingle(), sh.ReadSingle(), sh.ReadSingle(), sh.ReadSingle(),
         sh.ReadSingle(), sh.ReadSingle(), sh.ReadSingle(), sh.ReadSingle());
 
-    private static List<Volume> ReadVolumesOld(IGFile gameplayFile)
+    private static List<Volume> ReadVolumesOld(IGFile gameplayFile, DebugReader debugReader)
     {
         var volumeSection = gameplayFile.QuerySection(0x7740);
         var volumes = new Volume[volumeSection.count];
-        gameplayFile.sh.Seek(volumeSection.offset);
         for (int i = 0; i < volumeSection.count; i++)
         {
-            volumes[i] = new Volume((ulong)i, ReadMatrix4x4(gameplayFile.sh));
+            // Old-engine volume entries are 0x90 bytes each: a 0x40-byte (16-float, row-major,
+            // same convention as TieBound/new-engine volumes) transform matrix followed by 0x50
+            // bytes of still-unidentified trailing data — confirmed against ReLunacy-Ymir's own
+            // OldVolumeInstance, which documents this exact layout and explicitly warns against
+            // reading it as a packed array of bare matrices. Reading with no stride skip (what
+            // this used to do — sequential 0x40-byte reads with no gap) meant every entry after
+            // the first started inside the PREVIOUS entry's unknown trailing bytes instead of at
+            // its own real matrix: since gcd(0x40, 0x90) leaves a common period of 9 iterations
+            // (9 * 0x40 == 4 * 0x90), only every 9th "volume" happened to land back on a genuine
+            // entry boundary and decode correctly — everything else decomposed into a garbled
+            // scale/rotation, which reads as a visibly wrong-shaped/wrong-proportioned volume.
+            gameplayFile.sh.Seek(volumeSection.offset + i * 0x90);
+            string name = debugReader.GetVolumeName(i) ?? $"Volume_{i}";
+            volumes[i] = new Volume((ulong)i, ReadMatrix4x4(gameplayFile.sh), name);
         }
         return [.. volumes];
     }

--- a/ReLunacy.Engine/Loading/TextureShaderLoader.cs
+++ b/ReLunacy.Engine/Loading/TextureShaderLoader.cs
@@ -50,9 +50,15 @@ public sealed class TextureShaderLoader
 
         var alstream = assetlookup.sh;
         var hmstream = new StreamHelper(highmipstream, StreamHelper.Endianness.Big);
+        var texstream = new StreamHelper(texturestream, StreamHelper.Endianness.Big);
 
         var highmipsPtrSec = assetlookup.QuerySection(Texture.HighmipsPointerID);
         var textureMetaSec = assetlookup.QuerySection(TextureMetadataNew.ID);
+        // Lower-resolution single-mip fallback copies, embedded directly in textures.dat,
+        // index-aligned with the metadata/highmip-pointer tables above — see
+        // Texture.ReadTexture's lowres fallback branch. Absent on some levels (QuerySection
+        // returns a zero-length default header when the section doesn't exist at all).
+        var textureRefSec = assetlookup.QuerySection(0x1D180);
 
         alstream.Seek(highmipsPtrSec.offset);
         var highmipsPtrs = AssetPointer.ReadArray(alstream, highmipsPtrSec.length / 0x10);
@@ -71,7 +77,15 @@ public sealed class TextureShaderLoader
             // above made this loop run more than once (id=0 duplicate on the 2nd texture).
             var tex = new Texture(alstream) { highmipsRef = highmipsPtrs[i], id = highmipsPtrs[i].TUID };
             Textures.Add(tex.id, tex);
-            tex.ReadTexture(hmstream);
+
+            AssetPointer? lowresRef = null;
+            if (textureRefSec.length >= (i + 1) * 0x10)
+            {
+                alstream.Seek(textureRefSec.offset + i * 0x10);
+                lowresRef = new AssetPointer(alstream);
+            }
+
+            tex.ReadTexture(hmstream, texstream, lowresRef);
         }
     }
 
@@ -112,21 +126,33 @@ public sealed class TextureShaderLoader
                 texstreamReferences.Add(TexstreamReference.Read(mainStream));
             }
 
+            // texstreamReferences.index is the TARGET texture's index, not a 1:1 position in this
+            // list — a texstream override only exists for a subset of textures. The previous loop
+            // used its own counter `i` as both the reference-list position AND the texture-array
+            // index, which are different things: any reference whose own .index was >=
+            // texstreamRefSection.count (entirely plausible — the ref list only has as many
+            // entries as overridden textures, which can be indexed anywhere in the full texture
+            // table) was silently skipped, and the reference actually found at position i was
+            // applied to the wrong texture whenever the two diverged.
             var textureList = Textures.Values.ToArray();
-            for (uint i = 0; i < texstreamRefSection.count; i++)
+            foreach (var texstreamref in texstreamReferences)
             {
-                if (!texstreamReferences.Any(otr => otr.index == i))
-                    continue;
-
-                var texstreamref = texstreamReferences.Find(otr => otr.index == i);
-                textureList[i].highmipsMetadatasOld?.Add(texstreamref);
+                if (texstreamref.index < textureList.Length)
+                    textureList[texstreamref.index].highmipsMetadatasOld?.Add(texstreamref);
             }
         }
 
-        var streamToRead = texstream ?? textures;
+        // Per texture, not a single stream for the whole level: only textures with their own
+        // texstream override (highmipsMetadatasOld non-empty) read from texstream.dat — its
+        // offsets are meaningless against textures.dat and vice versa. The previous single
+        // `streamToRead = texstream ?? textures` read EVERY texture from texstream.dat whenever
+        // that file existed at all, even textures with no override entry, seeking to garbage
+        // offsets for all of them — texstream.dat only overrides a subset of textures on levels
+        // that have one at all (e.g. Tools of Destruction's meridian_city).
         foreach (var tex in Textures.Values)
         {
-            tex.ReadTexture(streamToRead);
+            bool hasOverride = (tex.highmipsMetadatasOld?.Count ?? 0) > 0;
+            tex.ReadTexture(hasOverride && texstream is not null ? texstream : textures);
         }
     }
 

--- a/ReLunacy.Engine/Loading/Textures/Texture.cs
+++ b/ReLunacy.Engine/Loading/Textures/Texture.cs
@@ -23,16 +23,26 @@ public class Texture
     public ITextureMetadata textureMetadata;
     public bool isOld;
 
+    private static readonly HashSet<ulong> _loggedSuspiciousTextures = [];
+
+    // Block-compressed formats are always read/stored linear regardless of the per-instance
+    // linear bit/prefix (see TextureMetadataOld/New.IsLinear) — DXT/BC compression has no
+    // swizzled-on-disk variant in this format family.
+    private static bool IsBlockCompressed(TextureFormat format) =>
+        format is TextureFormat.DXT1 or TextureFormat.DXT3 or TextureFormat.DXT5 or TextureFormat.BC4 or TextureFormat.BC5;
+
     public uint HighmipSize
     {
         get
         {
             return TexFormat switch
             {
-                TextureFormat.DXT1 => Math.Max(1, (Width + 3) / 4) * Math.Max(1, (Height + 3) / 4) * 8,
-                TextureFormat.DXT3 or TextureFormat.DXT5 => Math.Max(1, (Width + 3) / 4) * Math.Max(1, (Height + 3) / 4) * 16,
+                TextureFormat.DXT1 or TextureFormat.BC4 => Math.Max(1, (Width + 3) / 4) * Math.Max(1, (Height + 3) / 4) * 8,
+                TextureFormat.DXT3 or TextureFormat.DXT5 or TextureFormat.BC5 => Math.Max(1, (Width + 3) / 4) * Math.Max(1, (Height + 3) / 4) * 16,
                 TextureFormat.A8R8G8B8 => Width * Height * 4u,
-                TextureFormat.R5G6B5 => Width * Height * 2u,
+                TextureFormat.RGBA16F => Width * Height * 8u,
+                TextureFormat.R5G6B5 or TextureFormat.A1R5G5B5 or TextureFormat.G8B8 or TextureFormat.RGBA4 => Width * Height * 2u,
+                TextureFormat.R8 => Width * Height,
                 _ => 0,
             };
         }
@@ -69,10 +79,13 @@ public class Texture
         id = highmipsRef.Value.TUID;
     }
 
-    /// <summary>In new engine, stream must be the highmips stream.</summary>
-    public void ReadTexture(StreamHelper sh)
+    /// <summary>In new engine, <paramref name="sh"/> must be the highmips stream. <paramref name="lowresStream"/>/
+    /// <paramref name="lowresRef"/> (new engine only) are the assetlookup 0x1D180 fallback — a single-mip copy
+    /// embedded directly in textures.dat, used when this texture has no highmip data at all.</summary>
+    public void ReadTexture(StreamHelper sh, StreamHelper? lowresStream = null, AssetPointer? lowresRef = null)
     {
         int offset;
+        StreamHelper source = sh;
         if (isOld)
         {
             if ((highmipsMetadatasOld?.Count ?? 0) > 0)
@@ -94,37 +107,70 @@ public class Texture
                 throw new InvalidOperationException("Highmips reference is null. It must be read before reading the texture in new engine!");
 
             var hmref = highmipsRef.Value;
-            offset = (int)hmref.offset;
-            if (hmref.length == 0)
+            if (hmref.length > 0)
+            {
+                offset = (int)hmref.offset;
+                data = new byte[hmref.length];
+
+                // Diagnostic: the highmip entry's own length should match what the block decoder
+                // will actually expect for this texture's Width/Height/format — if it doesn't,
+                // the decoder gets handed a buffer that's the wrong size for the dimensions it's
+                // told to decode, which for a short buffer reads as flat/degenerate output (the
+                // reported new-engine DXT1/DXT5 "unicolor" symptom) without throwing anything.
+                if (IsBlockCompressed(TexFormat) && _loggedSuspiciousTextures.Add(id) && hmref.length != HighmipSize)
+                    Console.WriteLine($"Diagnostic: texture {id:X} ('{name}') is {TexFormat} at {Width}x{Height} — highmip entry is {hmref.length} bytes but decoding at these dimensions expects {HighmipSize} bytes.");
+            }
+            else if (lowresStream is not null && lowresRef is { length: > 0 } lref && HighmipSize > 0)
+            {
+                // No highmip data for this texture — fall back to the lower-resolution single-mip
+                // copy embedded directly in textures.dat (assetlookup section 0x1D180), same as
+                // ReLunacy-Ymir's `useLowres` path. Previously this case just returned with `data`
+                // left at its default `[]`, which decodes to null and renders as
+                // GlobalResource.DefaultModelTexture — a flat placeholder that looks exactly like
+                // the reported "unicolor" bug, for any texture whose highmip entry is legitimately
+                // empty (a normal, common case on new engine, not corruption).
+                source = lowresStream;
+                offset = (int)lref.offset;
+                data = new byte[HighmipSize];
+            }
+            else
             {
                 return;
             }
-            data = new byte[hmref.length];
         }
 
-        if (offset > sh.BaseStream.Length || offset < 0)
-            throw new IndexOutOfRangeException($"Offset is out of bounds: {offset:X}/{sh.BaseStream.Length:X}");
+        if (offset > source.BaseStream.Length || offset < 0)
+            throw new IndexOutOfRangeException($"Offset is out of bounds: {offset:X}/{source.BaseStream.Length:X}");
 
-        if (TexFormat > TextureFormat.A8R8G8B8)
+        // Whether to unswizzle is a per-instance property (see ITextureMetadata.IsLinear), not
+        // something derivable from the format alone — the previous `TexFormat > A8R8G8B8` check
+        // only worked by coincidence for the 5 formats that existed before this format list was
+        // expanded (every "> A8R8G8B8" format happened to also be DXT). It breaks for RGBA4/G8B8,
+        // which the new-engine prefix scheme can mark either swizzled OR linear per texture.
+        if (IsBlockCompressed(TexFormat) || textureMetadata.IsLinear)
         {
-            sh.Seek(offset);
-            sh.Read(data);
+            source.Seek(offset);
+            source.Read(data);
         }
         else
         {
-            sh.Seek(offset);
-            Unswizzle(sh);
+            source.Seek(offset);
+            Unswizzle(source);
         }
     }
 
     public void Unswizzle(StreamHelper sh)
     {
-        if ((int)TexFormat > (int)TextureFormat.A8R8G8B8) throw new InvalidOperationException("DXT formats aren't swizzled.");
+        if (IsBlockCompressed(TexFormat)) throw new InvalidOperationException("DXT/BC formats aren't swizzled.");
         if (data.Length <= 1) return;
 
-        int pixelSize = 0;
-        if (TexFormat == TextureFormat.R5G6B5) pixelSize = 2;
-        else if (TexFormat == TextureFormat.A8R8G8B8) pixelSize = 4;
+        int pixelSize = TexFormat switch
+        {
+            TextureFormat.R8 => 1,
+            TextureFormat.R5G6B5 or TextureFormat.A1R5G5B5 or TextureFormat.G8B8 or TextureFormat.RGBA4 => 2,
+            TextureFormat.A8R8G8B8 => 4,
+            _ => throw new ArgumentOutOfRangeException(nameof(TexFormat), TexFormat, "Unsupported format for unswizzle"),
+        };
 
         Span<byte> pixel = stackalloc byte[pixelSize];
 
@@ -138,6 +184,17 @@ public class Texture
 
     private static int MortonSwizzle(int index, int width, int height)
     {
+        // The row-stride multiplier below must be the ORIGINAL width, not the loop-shifted copy —
+        // `width` gets shifted down to 1 by the end of the loop below (that's how it tracks when
+        // to stop consuming bits for the X axis), so using the parameter directly in the final
+        // `yMortonValue * width + xMortonValue` silently used a stride of 1 instead of the real
+        // row width. That collapses most (x,y) pairs onto the same handful of destination indices
+        // instead of spreading them across the full width*height buffer — every swizzled texture
+        // (every non-DXT, non-linear one — DXT/linear textures are read raw and never call this)
+        // came out scrambled, while unswizzled reads looked fine, matching the reported symptom of
+        // some textures being broken and others not. ReLunacy-Ymir's equivalent Morton() takes the
+        // same approach but keeps the original `x` parameter untouched for exactly this reason.
+        int originalWidth = width;
         int bitPositionMultiplierY, bitPositionMultiplierX = bitPositionMultiplierY = 1;
         int yMortonValue, xMortonValue = yMortonValue = 0;
 
@@ -159,6 +216,6 @@ public class Texture
             }
         }
 
-        return yMortonValue * width + xMortonValue;
+        return yMortonValue * originalWidth + xMortonValue;
     }
 }

--- a/ReLunacy.Engine/Loading/Textures/TextureFormat.cs
+++ b/ReLunacy.Engine/Loading/Textures/TextureFormat.cs
@@ -1,10 +1,24 @@
 namespace ReLunacy.Engine.Loading.Textures;
 
+// Values match the raw 4-bit old-engine format code (TextureMetadataOld's (formatBitfield >> 8) &
+// 0xF) directly, ported from ReLunacy-Ymir's CTexture.TexFormat — that fork's texture handling is
+// confirmed working across formats this enum previously didn't even have members for (R8,
+// A1R5G5B5, BC4, BC5, G8B8), which is why old-engine levels using those formats (e.g. Tools of
+// Destruction's meridian_city) failed to decode. RGBA4/RGBA16F can't come from the old-engine 4-bit
+// mask at all (new-engine only, selected by TextureMetadataNew's format-byte prefix instead), so
+// they keep the fork's original raw byte values (0x83/0x9A) to avoid colliding with 0x00-0x0F.
 public enum TextureFormat
 {
+    R8 = 0x01,
     R5G6B5 = 0x03,
+    A1R5G5B5 = 0x04,
     A8R8G8B8 = 0x05,
     DXT1 = 0x06,
     DXT3 = 0x07,
-    DXT5 = 0x08
+    DXT5 = 0x08,
+    BC4 = 0x09,
+    BC5 = 0x0A,
+    G8B8 = 0x0B,
+    RGBA4 = 0x83,
+    RGBA16F = 0x9A,
 }

--- a/ReLunacy.Engine/Loading/Textures/TextureMetadataNew.cs
+++ b/ReLunacy.Engine/Loading/Textures/TextureMetadataNew.cs
@@ -16,8 +16,54 @@ public record struct TextureMetadataNew : ILunaSerializable, ITextureMetadata
 
     public readonly uint Width => (uint)1 << widthPow;
     public readonly uint Height => (uint)1 << heightPow;
-    public readonly TextureFormat Format => (TextureFormat)format;
+
+    // New engine's raw format byte is NOT the same numbering as old engine's 4-bit code — it's
+    // prefixed 0x8X (Morton-swizzled) or 0xAX (linear), plus a couple of bare/special values
+    // (0x01-0x0B, 0x9A). The previous `(TextureFormat)format` cast skipped this normalization
+    // entirely, so every new-engine texture whose format byte didn't happen to equal one of
+    // TextureFormat's raw old-engine values (3/5/6/7/8) decoded to a garbage enum value instead —
+    // ported from ReLunacy-Ymir's CTexture.NormalizeNewEngineFormat, which is confirmed working.
+    public readonly TextureFormat Format => NormalizeFormat(format);
+
+    // 0xAX prefix and 0x9A (RGBA16F) are always linear; DXT/BC are always linear regardless of
+    // prefix; everything else (0x8X prefix, or a bare unprefixed byte) is swizzled. Ported from
+    // CTexture.NewEngineFormatIsLinear.
+    public readonly bool IsLinear => FormatIsLinear(format);
+
     public readonly ushort MipmapCount => mipmapCount;
+
+    private static readonly HashSet<byte> _loggedFormatBytes = [];
+
+    private static TextureFormat NormalizeFormat(byte raw)
+    {
+        if (_loggedFormatBytes.Add(raw))
+            Console.WriteLine($"Diagnostic: new-engine texture format byte 0x{raw:X2} seen (normalizes to {NormalizeFormatCore(raw)}).");
+
+        return NormalizeFormatCore(raw);
+    }
+
+    private static TextureFormat NormalizeFormatCore(byte raw) => raw switch
+    {
+        0x81 or 0xA1 or 0x01 => TextureFormat.R8,
+        0x82 or 0xA2 or 0x04 => TextureFormat.A1R5G5B5,
+        0x83 or 0xA3 => TextureFormat.RGBA4,
+        0x84 or 0xA4 or 0x03 => TextureFormat.R5G6B5,
+        0x85 or 0xA5 or 0x05 => TextureFormat.A8R8G8B8,
+        0x86 or 0xA6 or 0x06 => TextureFormat.DXT1,
+        0x87 or 0xA7 or 0x07 => TextureFormat.DXT3,
+        0x88 or 0xA8 or 0x08 => TextureFormat.DXT5,
+        0x8B or 0xAB or 0x0B => TextureFormat.G8B8,
+        0x9A => TextureFormat.RGBA16F,
+        _ => (TextureFormat)0xFF, // unrecognized — Texture.ReadTexture must treat this as unreadable
+    };
+
+    private static bool FormatIsLinear(byte raw)
+    {
+        if (raw is >= 0xA0 and <= 0xAF) return true;
+        if (raw == 0x9A) return true;
+        var fmt = NormalizeFormatCore(raw);
+        return fmt is TextureFormat.DXT1 or TextureFormat.DXT3 or TextureFormat.DXT5;
+    }
 
     public static TextureMetadataNew Read(StreamHelper sh) => FileUtils.ReadStructure<TextureMetadataNew>(sh);
 

--- a/ReLunacy.Engine/Loading/Textures/TextureMetadataOld.cs
+++ b/ReLunacy.Engine/Loading/Textures/TextureMetadataOld.cs
@@ -22,6 +22,13 @@ public record struct TextureMetadataOld : ILunaSerializable, ITextureMetadata
     public readonly TextureFormat Format => (TextureFormat)((formatBitfield >> 8) & 0x0F);
     public readonly ushort MipmapCount => mipmapCount;
 
+    // Bit 2 of formatBitfield, per ReLunacy-Ymir's CTexture (OldTextureReference doc comment:
+    // "shift 2 | bits 1 | if 1 then unswizzled (linear), ignored on DXT formats"). DXT/BC formats
+    // are always linear regardless of this bit, same as new engine.
+    public readonly bool IsLinear =>
+        Format is TextureFormat.DXT1 or TextureFormat.DXT3 or TextureFormat.DXT5 or TextureFormat.BC4 or TextureFormat.BC5
+        || ((formatBitfield >> 2) & 1) != 0;
+
     // Unk1 (0x08-0x18) has never been decoded — it's raw, unexamined bytes. This struct's ID
     // (0x5200) and total size (0x20) match InsomniaToolset's PS3 "NV4097_SET_*TEXTURE_*
     // registry dump" Texture struct field-for-field where it's been verified (offset/numMips at
@@ -35,7 +42,19 @@ public record struct TextureMetadataOld : ILunaSerializable, ITextureMetadata
     // nothing reads this for actual rendering decisions yet.
     public readonly bool AlphaKillCandidate => Unk1 != null && Unk1.Length > 7 && (Unk1[7] & 0x20) != 0;
 
-    public static TextureMetadataOld Read(StreamHelper sh) => FileUtils.ReadStructure<TextureMetadataOld>(sh);
+    // One-shot diagnostic: which old-engine formatBitfield values actually appear in real level
+    // data, and whether the per-instance linear bit (bit 2) is ever set. Neither the format-code
+    // range nor that bit has been confirmed against real data before now — this settles both from
+    // the next level load instead of assuming the ReLunacy-Ymir port's decode is exhaustive.
+    private static readonly HashSet<ushort> _loggedFormatBitfields = [];
+
+    public static TextureMetadataOld Read(StreamHelper sh)
+    {
+        var meta = FileUtils.ReadStructure<TextureMetadataOld>(sh);
+        if (_loggedFormatBitfields.Add(meta.formatBitfield))
+            Console.WriteLine($"Diagnostic: old-engine texture formatBitfield 0x{meta.formatBitfield:X4} seen (format={meta.Format}, linearBit={((meta.formatBitfield >> 2) & 1) != 0}).");
+        return meta;
+    }
 
     public byte[] ToBytes(bool isOld, params object[]? additionalParams) => throw new NotImplementedException();
 }

--- a/ReLunacy.Engine/Rendering/TextureUtils.cs
+++ b/ReLunacy.Engine/Rendering/TextureUtils.cs
@@ -46,6 +46,12 @@ public static class TextureUtils
     private static readonly BlockDecoder Bc1Decoder = BlockDecoder.Create(BlockFormat.BC1);
     private static readonly BlockDecoder Bc2Decoder = BlockDecoder.Create(BlockFormat.BC2);
     private static readonly BlockDecoder Bc3Decoder = BlockDecoder.Create(BlockFormat.BC3);
+    // Unsigned variants: no confirmed case in this game's assets needs signed BC4/BC5 data, and
+    // ReconstructZ (which derives a normal map's Z from X/Y) isn't used here since this decode
+    // path is generic — it's shared by plain texture export too, where injecting a normal-map
+    // assumption into every BC5 texture would be wrong.
+    private static readonly BlockDecoder Bc4Decoder = BlockDecoder.Create(BlockFormat.BC4U);
+    private static readonly BlockDecoder Bc5Decoder = BlockDecoder.Create(BlockFormat.BC5U);
 
     /// <summary>
     /// Decodes an ITexture's raw (possibly block-compressed) pixel data to a plain RGBA8888
@@ -65,10 +71,17 @@ public static class TextureUtils
         return texture.Format switch
         {
             Assets.Interfaces.TextureFormat.R5G6B5 => RGB565ToRGBA8888(raw, width, height),
+            Assets.Interfaces.TextureFormat.A1R5G5B5 => A1RGB555ToRGBA8888(raw, width, height),
+            Assets.Interfaces.TextureFormat.RGBA4 => RGBA4444ToRGBA8888(raw, width, height),
             Assets.Interfaces.TextureFormat.A8R8G8B8 => ARGB8888ToRGBA8888(raw, width, height),
+            Assets.Interfaces.TextureFormat.R8 => R8ToRGBA8888(raw, width, height),
+            Assets.Interfaces.TextureFormat.G8B8 => G8B8ToRGBA8888(raw, width, height),
+            Assets.Interfaces.TextureFormat.RGBA16F => RGBA16FToRGBA8888(raw, width, height),
             Assets.Interfaces.TextureFormat.DXT1 => Bc1Decoder.Decode(width, height, raw),
             Assets.Interfaces.TextureFormat.DXT3 => Bc2Decoder.Decode(width, height, raw),
             Assets.Interfaces.TextureFormat.DXT5 => Bc3Decoder.Decode(width, height, raw),
+            Assets.Interfaces.TextureFormat.BC4 => Bc4Decoder.Decode(width, height, raw),
+            Assets.Interfaces.TextureFormat.BC5 => Bc5Decoder.Decode(width, height, raw),
             _ => null,
         };
     }
@@ -144,6 +157,22 @@ public static class TextureUtils
         return img;
     }
 
+    /// <summary>Reassembles a big-endian (disk-order) 16-bit pixel from a 2-byte source. All the
+    /// 16-bit format decoders below read from data already loaded as-is off disk (StreamHelper's
+    /// stream is big-endian, and Texture.Unswizzle/ReadTexture don't reorder bytes — see those for
+    /// why), so byte0 is always the high byte.</summary>
+    private static ushort ReadPixel16(byte[] rawData, int i) => (ushort)((rawData[i * 2] << 8) | rawData[i * 2 + 1]);
+
+    /// <summary>Expands an N-bit channel value to 8 bits by replicating its high bits into the low
+    /// bits (e.g. 5-bit 11111 -> 11111111, not 11111000) — the standard bit-replication expansion,
+    /// avoids the low end of the range never reaching full brightness/darkness.</summary>
+    private static byte Expand(int value, int bits) => (byte)((value << (8 - bits)) | (value >> (2 * bits - 8)));
+
+    // Previously computed R/B by right-shifting a 5-bit field into the top of an 8-bit channel
+    // with no expansion (max output ~0x1F, i.e. red/blue could never exceed ~12% brightness), and
+    // G by OR-ing an unshifted byte1 high-bits term against a shifted byte0 low-bits term — the
+    // two write to overlapping bit positions instead of adjacent ones, corrupting green on every
+    // pixel. Fixed by unpacking the full 16-bit word first, then expanding each channel properly.
     public static byte[] RGB565ToRGBA8888(in byte[] rawData, int width, int height)
     {
         const int Rgb565Ps = 2;
@@ -156,10 +185,116 @@ public static class TextureUtils
 
         for (int i = 0; i < pixelCount; i++)
         {
-            result[i * Rgba8888Ps + 0] = (byte)((rawData[i * Rgb565Ps + 0] & 0b11111000) >> 3);
-            result[i * Rgba8888Ps + 1] = (byte)((byte)((rawData[i * Rgb565Ps + 0] & 0b00000111) << 3) | (byte)(rawData[i * Rgb565Ps + 1] & 0b11100000));
-            result[i * Rgba8888Ps + 2] = (byte)(rawData[i * Rgb565Ps + 1] & 0b00011111);
+            ushort px = ReadPixel16(rawData, i);
+            result[i * Rgba8888Ps + 0] = Expand((px >> 11) & 0x1F, 5);
+            result[i * Rgba8888Ps + 1] = Expand((px >> 5) & 0x3F, 6);
+            result[i * Rgba8888Ps + 2] = Expand(px & 0x1F, 5);
             result[i * Rgba8888Ps + 3] = 0xFF;
+        }
+
+        return result;
+    }
+
+    /// <summary>Bit layout (MSB->LSB) A1 R5 G5 B5 — matches the format name and the equivalent
+    /// bare-Vulkan/D3D "A1R5G5B5" convention, not independently confirmed against real data.</summary>
+    public static byte[] A1RGB555ToRGBA8888(in byte[] rawData, int width, int height)
+    {
+        const int DstPs = 4;
+        int pixelCount = width * height;
+        byte[] result = new byte[pixelCount * DstPs];
+
+        for (int i = 0; i < pixelCount; i++)
+        {
+            ushort px = ReadPixel16(rawData, i);
+            result[i * DstPs + 0] = Expand((px >> 10) & 0x1F, 5);
+            result[i * DstPs + 1] = Expand((px >> 5) & 0x1F, 5);
+            result[i * DstPs + 2] = Expand(px & 0x1F, 5);
+            result[i * DstPs + 3] = (byte)(((px >> 15) & 0x1) * 0xFF);
+        }
+
+        return result;
+    }
+
+    /// <summary>Bit layout (MSB->LSB) R4 G4 B4 A4, following the format name's channel order —
+    /// unconfirmed against real data; if colors look swapped/tinted on a real RGBA4 texture, this
+    /// is the first thing to try reordering (e.g. to A4R4G4B4).</summary>
+    public static byte[] RGBA4444ToRGBA8888(in byte[] rawData, int width, int height)
+    {
+        const int DstPs = 4;
+        int pixelCount = width * height;
+        byte[] result = new byte[pixelCount * DstPs];
+
+        for (int i = 0; i < pixelCount; i++)
+        {
+            ushort px = ReadPixel16(rawData, i);
+            result[i * DstPs + 0] = Expand((px >> 12) & 0xF, 4);
+            result[i * DstPs + 1] = Expand((px >> 8) & 0xF, 4);
+            result[i * DstPs + 2] = Expand((px >> 4) & 0xF, 4);
+            result[i * DstPs + 3] = Expand(px & 0xF, 4);
+        }
+
+        return result;
+    }
+
+    /// <summary>Single 8-bit channel, replicated across R/G/B for a legible grayscale view (same
+    /// convention as ColourAsMain below) rather than left only in the red channel.</summary>
+    public static byte[] R8ToRGBA8888(in byte[] rawData, int width, int height)
+    {
+        const int DstPs = 4;
+        int pixelCount = width * height;
+        byte[] result = new byte[pixelCount * DstPs];
+
+        for (int i = 0; i < pixelCount; i++)
+        {
+            byte v = rawData[i];
+            result[i * DstPs + 0] = v;
+            result[i * DstPs + 1] = v;
+            result[i * DstPs + 2] = v;
+            result[i * DstPs + 3] = 0xFF;
+        }
+
+        return result;
+    }
+
+    /// <summary>byte0=G, byte1=B per the format name's order (commonly a 2-channel tangent-space
+    /// normal map XY pair in other engines, but that's not confirmed for this game) — unconfirmed
+    /// against real data, same caveat as RGBA4444ToRGBA8888.</summary>
+    public static byte[] G8B8ToRGBA8888(in byte[] rawData, int width, int height)
+    {
+        const int SrcPs = 2, DstPs = 4;
+        int pixelCount = width * height;
+        byte[] result = new byte[pixelCount * DstPs];
+
+        for (int i = 0; i < pixelCount; i++)
+        {
+            result[i * DstPs + 0] = 0;
+            result[i * DstPs + 1] = rawData[i * SrcPs + 0];
+            result[i * DstPs + 2] = rawData[i * SrcPs + 1];
+            result[i * DstPs + 3] = 0xFF;
+        }
+
+        return result;
+    }
+
+    /// <summary>4x 16-bit half-float channels (RGBA), clamped to [0,1] and scaled to 8-bit since
+    /// the output target here is always an LDR buffer (GPU upload or PNG export) — HDR values
+    /// above 1.0 just clip rather than tone-map. Byte order matches ReadPixel16 (big-endian
+    /// disk-order halves).</summary>
+    public static byte[] RGBA16FToRGBA8888(in byte[] rawData, int width, int height)
+    {
+        const int DstPs = 4;
+        int pixelCount = width * height;
+        byte[] result = new byte[pixelCount * DstPs];
+
+        for (int i = 0; i < pixelCount; i++)
+        {
+            for (int c = 0; c < 4; c++)
+            {
+                int srcIdx = i * 8 + c * 2;
+                ushort halfBits = (ushort)((rawData[srcIdx] << 8) | rawData[srcIdx + 1]);
+                float value = (float)BitConverter.UInt16BitsToHalf(halfBits);
+                result[i * DstPs + c] = (byte)(Math.Clamp(value, 0f, 1f) * 0xFF);
+            }
         }
 
         return result;

--- a/ReLunacy/Core/Frames/DockedFrames/AssetViewer.cs
+++ b/ReLunacy/Core/Frames/DockedFrames/AssetViewer.cs
@@ -76,6 +76,7 @@ public class AssetViewer : DockedFrame, ILevelListener
     public Vector2 RenderFramePos { get; private set; }
     public Vector2 MousePos { get; private set; }
     public MouseGrabHandler rmbghandler = new() { mouseButton = Bliss.CSharp.Interact.Mice.MouseButton.Right };
+    public MouseGrabHandler mmbghandler = new() { mouseButton = Bliss.CSharp.Interact.Mice.MouseButton.Middle };
     private readonly GraphicsDevice graphicsDevice;
     private RenderTexture2D renderTexture;
     private readonly IRenderer renderer;
@@ -655,7 +656,10 @@ public class AssetViewer : DockedFrame, ILevelListener
 
         HorizontalSplitter("##split_preview", ref previewHeight, rightWidth);
 
-        ImGui.Text($"{RenderFrameSize.Width}x{RenderFrameSize.Height} - Distance to origin: {Camera.Position.Length()}m");
+        // Distance to Target (the orbit pivot), not Camera.Position.Length() (distance to world
+        // zero) — those were the same thing before middle-click pan could move Target away from
+        // Vector3.Zero, but "distance to origin" now means "distance to wherever the pivot is."
+        ImGui.Text($"{RenderFrameSize.Width}x{RenderFrameSize.Height} - Distance to target: {Vector3.Distance(Camera.Position, Camera.Target)}m");
         ImGui.Separator();
 
         // Lower part split vertically: asset info/shaders/export on the left (unchanged content),
@@ -848,7 +852,7 @@ public class AssetViewer : DockedFrame, ILevelListener
         Point absMousePos = new((int)windowMousePos.X, (int)windowMousePos.Y);
         bool isHoveringWnd = ImGui.IsWindowHovered();
         bool isMouseInCntReg = RenderFrameSize.Contains(absMousePos);
-        CheckRotationInput(isMouseInCntReg);
+        CheckCameraDragInput(isMouseInCntReg);
 
         // Scroll-zoom is independent of the RMB rotate-drag and gated purely on hovering the
         // render image, not "anywhere in the window" — otherwise scrolling while reading the
@@ -1118,27 +1122,75 @@ public class AssetViewer : DockedFrame, ILevelListener
             height += ImGui.GetIO().MouseDelta.Y;
     }
 
-    private void CheckRotationInput(bool allowGrab)
+    // Tracks the previous frame's drag state so the shared NoMouse flag (below) is only touched
+    // on a rising/falling edge, not every frame.
+    private bool wasDragging;
+
+    /// <summary>RMB drags orbit (rotates Position around the fixed Target); MMB drags pan (moves
+    /// Position and Target together, so the orbit origin itself relocates instead of just
+    /// spinning around it). Both share one method rather than two independent ones because they
+    /// also share the ImGuiConfigFlags.NoMouse relative-mouse-mode flag: two separate methods each
+    /// unconditionally setting/clearing that flag would have the second one clobber whatever the
+    /// first just set whenever only one of the two buttons is actually held.</summary>
+    private void CheckCameraDragInput(bool allowGrab)
     {
         ImGuiIOPtr io = ImGui.GetIO();
-        if (rmbghandler.TryGrabMouse(allowGrab))
-        {
+        bool rotating = rmbghandler.TryGrabMouse(allowGrab);
+        bool panning = mmbghandler.TryGrabMouse(allowGrab);
+        bool isDragging = rotating || panning;
+
+        // Edge-triggered, not level-triggered: NoMouse is also written by View3D's own drag
+        // handling (same relative-mouse-mode pattern, different viewport). Unconditionally
+        // clearing it every frame this viewport has nothing grabbed — what this used to do — would
+        // cut off a drag in progress over there if both frames tick within the same pass.
+        if (isDragging && !wasDragging)
             io.ConfigFlags |= ImGuiConfigFlags.NoMouse;
-        }
-        else
-        {
+        else if (!isDragging && wasDragging)
             io.ConfigFlags &= ~ImGuiConfigFlags.NoMouse;
-            return;
+        wasDragging = isDragging;
+
+        if (!isDragging) return;
+
+        Vector2 delta = Input.GetMouseDelta();
+
+        if (rotating)
+        {
+            Vector2 rot = delta * Program.Settings.CamSensivity;
+
+            // rotateAroundTarget: true swings Position around the fixed Target (real orbit).
+            // false — what this used to pass — keeps Position fixed and swings Target instead,
+            // which is FPS-style look, not an orbit; that's why this never actually orbited.
+            Camera.SetPitch(Camera.GetPitch() - rot.Y, true);
+            Camera.SetYaw(Camera.GetYaw() - rot.X, true);
         }
 
-        Vector2 rot = Input.GetMouseDelta();
-        rot *= Program.Settings.CamSensivity;
+        if (panning)
+        {
+            // Screen-pixel delta -> world-space delta at the orbit target's own depth (same
+            // perspective back-solve as WorldScaleForPixelRadius, without that method's
+            // billboard-specific 0.005 constant), so the point under the cursor at drag-start
+            // stays roughly under the cursor while dragging, matching typical middle-click-pan
+            // tools.
+            float distance = Vector3.Distance(Camera.Position, Camera.Target);
+            float fovYRad = Camera.Fov * (MathF.PI / 180f);
+            float worldUnitsPerPixel = 2f * distance * MathF.Tan(fovYRad * 0.5f) / Math.Max(1, RenderFrameSize.Height);
 
-        // rotateAroundTarget: true swings Position around the fixed Target (real orbit).
-        // false — what this used to pass — keeps Position fixed and swings Target instead,
-        // which is FPS-style look, not an orbit; that's why this never actually orbited.
-        Camera.SetPitch(Camera.GetPitch() - rot.Y, true);
-        Camera.SetYaw(Camera.GetYaw() - rot.X, true);
+            // Built by hand instead of Cam3D.MoveRight/MoveUp: those use GetRight() = Cross(Forward,
+            // Up) and the raw Up field directly, neither of which is normalized — Up drifts and
+            // isn't guaranteed orthogonal to Forward after SetPitch/SetRoll, so pan speed would
+            // vary with pitch (shrinking toward zero looking straight up/down) and drift over time.
+            // right/up here are a proper orthonormal basis for the current view.
+            Vector3 forward = Camera.GetForward();
+            Vector3 right = Vector3.Normalize(Vector3.Cross(forward, Camera.Up));
+            Vector3 up = Vector3.Normalize(Vector3.Cross(right, forward));
+
+            // Signs make the dragged point track the cursor (drag right -> content follows right,
+            // i.e. camera moves left; drag down -> content follows down, i.e. camera moves up) —
+            // not runtime-verified; if the pan feels inverted, flip both signs here.
+            Vector3 shift = right * (-delta.X * worldUnitsPerPixel) + up * (delta.Y * worldUnitsPerPixel);
+            Camera.Position += shift;
+            Camera.Target += shift;
+        }
     }
 
     private void UpdateWindowSize()

--- a/ReLunacy/Core/Frames/DockedFrames/TexturesExplorer.cs
+++ b/ReLunacy/Core/Frames/DockedFrames/TexturesExplorer.cs
@@ -159,6 +159,14 @@ public class TexturesExplorer : DockedFrame, ILevelListener
         return true;
     }
 
+    // Texture names come straight from the game's own string tables, which for some formats
+    // (e.g. new-engine shader-referenced texture names) are full slash-delimited asset paths,
+    // not bare filenames — writing that as-is into Path.Combine either creates unwanted nested
+    // directories under Extracted/ or fails outright. Keep only the last path segment, and fall
+    // back to the texture's index (not e.g. "unnamed") when it has no name at all.
+    private static string GetExportFileName(string? textureName, int index) =>
+        string.IsNullOrEmpty(textureName) ? $"Tex_{index}" : textureName.Split('/')[^1];
+
     private static bool MaterialUsesTexture(IMaterial mat, ulong textureId) =>
         mat.AlbedoTexture?.Id == textureId ||
         mat.NormalTexture?.Id == textureId ||
@@ -396,7 +404,7 @@ public class TexturesExplorer : DockedFrame, ILevelListener
                     if (!Directory.Exists(path))
                         Directory.CreateDirectory(path);
 
-                    File.WriteAllBytes(Path.Combine(path, selection.TextureName != null ? selection.TextureName + ".raw" : $"Tex_{selectedTexture}.raw"), selection.Texture.GetPixelData());
+                    File.WriteAllBytes(Path.Combine(path, GetExportFileName(selection.TextureName, selectedTexture) + ".raw"), selection.Texture.GetPixelData());
                 }
                 ImGui.SameLine();
                 if(ImGui.Button(LM.Get("GUI_Frame_TextureExplorer_Preview_ExportPNG")))
@@ -406,7 +414,7 @@ public class TexturesExplorer : DockedFrame, ILevelListener
                         Directory.CreateDirectory(path);
 
                     var clone = (Image)selection.BlissTexture.Images[0].Clone();
-                    clone.SaveAsPng(Path.Combine(path, selection.TextureName != null ? selection.TextureName + ".png" : $"Tex_{selectedTexture}.png"));
+                    clone.SaveAsPng(Path.Combine(path, GetExportFileName(selection.TextureName, selectedTexture) + ".png"));
                 }
                 ImGui.Separator();
                 if (ImGui.Button(LM.Get("GUI_Frame_TextureExplorer_Preview_FindUsages")))


### PR DESCRIPTION
…on logic

- Added support for new texture formats (R8, A1R5G5B5, RGBA4, RGBA16F, BC4, BC5, G8B8) in texture metadata, pixel data decoding, and format mappings.
- Fixed `RGB565ToRGBA8888` decoding issues by correctly expanding channel precision and unpacking pixel words.
- Decoded additional formats: A1RGB555, RGBA4444, R8, G8B8, and RGBA16F with accurate bit replication and clamping logic.
- Updated old engine volume reader to properly account for data strides, ensuring volume entries align correctly.
- Introduced `IsLinear` property for texture metadata to handle Morton-swizzling logic.
- Enhanced asset exporting by sanitizing texture names for compatibility with file systems.
- Fixed stream read logic in `TextureShaderLoader` to correctly handle texstream offsets and avoid invalid reads.
- Improved camera logic to support middle-click panning and adjusted "distance to target" calculations in asset viewer.
- Introduced `Expand` utility for precision channel expansion across multiple decoding methods.