### PR TITLE
Add lightmap UV support for ties and enhance texture handling

### DIFF
--- a/ReLunacy.Engine/Assets/Geometry/GeometryData.cs
+++ b/ReLunacy.Engine/Assets/Geometry/GeometryData.cs
@@ -10,6 +10,7 @@ public sealed class GeometryData : IGeometry
     private readonly float[] _uvs;
     private readonly float[]? _normals;
     private readonly float[] _tangents;
+    private readonly float[]? _lightmapUVs;
     private readonly float[]? _vertexAlphaCandidates;
     private readonly uint[] _indices;
     private readonly int[]? _jointIndices;
@@ -21,7 +22,8 @@ public sealed class GeometryData : IGeometry
     public bool IsLoaded => true;
 
     public GeometryData(ulong id, float[] positions, float[] uvs, uint[] indices, float[]? normals = null, BoundingSphere? boundingSphere = null,
-        int[]? jointIndices = null, float[]? jointWeights = null, float[]? vertexAlphaCandidates = null, float[]? tangents = null)
+        int[]? jointIndices = null, float[]? jointWeights = null, float[]? vertexAlphaCandidates = null, float[]? tangents = null,
+        float[]? lightmapUVs = null)
     {
         if (positions.Length % 3 != 0)
             throw new ArgumentException("Positions must be in groups of 3 (x,y,z)", nameof(positions));
@@ -40,6 +42,8 @@ public sealed class GeometryData : IGeometry
             throw new ArgumentException("Normal count must match vertex count");
         if (tangents != null && tangents.Length / 3 != vertexCount)
             throw new ArgumentException("Tangent count must match vertex count");
+        if (lightmapUVs != null && lightmapUVs.Length != vertexCount * 2)
+            throw new ArgumentException("Lightmap UV count must match vertex count", nameof(lightmapUVs));
         if (jointIndices != null && jointIndices.Length != vertexCount * 4)
             throw new ArgumentException("Joint index count must be vertex count * 4", nameof(jointIndices));
         if (jointWeights != null && jointWeights.Length != vertexCount * 4)
@@ -59,6 +63,7 @@ public sealed class GeometryData : IGeometry
         // UV gradients (and always derives the handedness sign, since the source format never
         // carries one either way — see GeometryMath.ComputeTangents).
         _tangents = GeometryMath.ComputeTangents(positions, uvs, _normals, indices, tangents);
+        _lightmapUVs = lightmapUVs;
         _vertexAlphaCandidates = vertexAlphaCandidates;
         _indices = indices;
         _jointIndices = jointIndices;
@@ -70,6 +75,7 @@ public sealed class GeometryData : IGeometry
     public float[] GetTextureCoordinates() => _uvs;
     public float[]? GetNormals() => _normals;
     public float[]? GetTangents() => _tangents;
+    public float[]? GetLightmapUVs() => _lightmapUVs;
     public float[]? GetVertexAlphaCandidates() => _vertexAlphaCandidates;
     public uint[] GetIndices() => _indices;
     public int[]? GetJointIndices() => _jointIndices;

--- a/ReLunacy.Engine/Assets/Interfaces/IGeometry.cs
+++ b/ReLunacy.Engine/Assets/Interfaces/IGeometry.cs
@@ -13,6 +13,14 @@ public interface IGeometry : IAsset
     /// how it's derived, including why `w` is always computed rather than read from source data.</summary>
     float[]? GetTangents();
 
+    /// <summary>Per-vertex LIGHTMAP UV, 2 floats per vertex, or null when this geometry has none.
+    /// Baked lighting is sampled here, not at GetTextureCoordinates() — the game's own tie vertex
+    /// program routes this attribute to tc0.zw and its base UV to tc0.xy (see
+    /// Loading.Vertices.TieLightmapUV). Currently supplied by ties only; UFrags carry their
+    /// equivalent through IUFrag.GetLightmapUVs() instead, since they don't go through
+    /// GeometryData.</summary>
+    float[]? GetLightmapUVs();
+
     /// <summary>Per-vertex decode of VertexFormat0's boneIndex-as-alpha candidate (see
     /// Material.UsesVertexAlphaCandidate) — null for geometry that doesn't carry it. Not
     /// necessarily meaningful data even when non-null; callers gate use on the material flag.</summary>

--- a/ReLunacy.Engine/Assets/Interfaces/ITie.cs
+++ b/ReLunacy.Engine/Assets/Interfaces/ITie.cs
@@ -8,4 +8,21 @@ public interface ITie : IAsset
     IReadOnlyList<IMesh> Meshes { get; }
     float Scale { get; }
     (Vector3 center, float radius) GetBoundingSphere();
+
+    /// <summary>LIGHTMAP UV channel, flat as [u0, v0, u1, v1, ...], or null when this tie has none.
+    /// Mirrors IUFrag.GetLightmapUVs(), with one structural difference worth knowing: a UFrag's
+    /// UVs address an island inside a shared zone atlas, whereas a tie's address its own private
+    /// baked texture — every lightmapped tie INSTANCE gets a distinct entry in zone sections 0x5400
+    /// and 0x5410 (see TieInstance.LightmapIndex), so these UVs cover the full [0,1] square and are
+    /// shared by every instance of the asset while the texture they sample is not.
+    ///
+    /// Indexed over the TIE's whole vertex buffer, not per mesh — TieMesh.verticesIndex is the
+    /// offset of a mesh's first vertex into this array.
+    ///
+    /// Non-null for the ties whose array is at the known location (61 of 193 on metropolis) and null
+    /// for the rest, which therefore render unlit. That is deliberate: a wrong offset would produce
+    /// in-range, plausible-looking UVs and light the tie incorrectly, which is much harder to notice
+    /// than no lighting at all. See Loading.Vertices.TieLightmapUV for the format, the evidence, and
+    /// where the remaining arrays are NOT.</summary>
+    float[]? GetLightmapUVs();
 }

--- a/ReLunacy.Engine/Assets/Ties/Tie.cs
+++ b/ReLunacy.Engine/Assets/Ties/Tie.cs
@@ -13,6 +13,10 @@ public sealed class Tie : ITie
     public IReadOnlyList<IMesh> Meshes { get; init; }
     public float Scale { get; init; }
 
+    /// <summary>Backing store for <see cref="GetLightmapUVs"/> — see ITie for the shape and for why
+    /// nothing sets it yet.</summary>
+    private readonly float[]? _lightmapUVs;
+
     private readonly Lazy<(Vector3 center, float radius)>? _boundingSphere;
 
     public Tie(
@@ -20,12 +24,14 @@ public sealed class Tie : ITie
         IReadOnlyList<IMesh> meshes,
         float scale = 1.0f,
         string? name = null,
-        Func<(Vector3, float)>? boundingSphereCalculator = null)
+        Func<(Vector3, float)>? boundingSphereCalculator = null,
+        float[]? lightmapUVs = null)
     {
         Id = id;
         Name = name;
         Meshes = meshes ?? throw new ArgumentNullException(nameof(meshes));
         Scale = scale;
+        _lightmapUVs = lightmapUVs;
         IsLoaded = true;
 
         if (boundingSphereCalculator != null)
@@ -33,6 +39,9 @@ public sealed class Tie : ITie
             _boundingSphere = new Lazy<(Vector3, float)>(boundingSphereCalculator);
         }
     }
+
+    /// <inheritdoc />
+    public float[]? GetLightmapUVs() => _lightmapUVs;
 
     public (Vector3 center, float radius) GetBoundingSphere()
     {

--- a/ReLunacy.Engine/Export/LevelExporter.cs
+++ b/ReLunacy.Engine/Export/LevelExporter.cs
@@ -193,6 +193,7 @@ public static class LevelExporter
         public float[] GetVertexPositions() => ufrag.GetVertexPositions();
         public float[] GetTextureCoordinates() => ufrag.GetTextureCoordinates();
         public float[]? GetNormals() => ufrag.GetNormals();
+        public float[]? GetLightmapUVs() => ufrag.GetLightmapUVs();
 
         // UFrag terrain carries no baked tangent (or, on some readers, even normal) data — derive
         // both from the triangle/UV data itself via the same fallback GeometryData uses for

--- a/ReLunacy.Engine/Loading/Objects/Tie.cs
+++ b/ReLunacy.Engine/Loading/Objects/Tie.cs
@@ -25,6 +25,13 @@ public class Tie : IDisposable
 
     public ulong[]? ShaderTUIDs;
 
+    /// <summary>RAW lightmap UV channel, flat [u0,v0,u1,v1,...] over the tie's whole vertex buffer,
+    /// or null when the read isn't even in bounds. See <see cref="TieLightmapUV"/> — this is RSX
+    /// attribute location 4, which the game's tie vertex program routes into tc0.zw.
+    /// Not every window in here is real UV data; validate PER MESH before use, as
+    /// TieReader.SliceLightmapUVs does.</summary>
+    public float[]? LightmapUVs { get; private set; }
+
     public Tie(IGFile file, FileManager fm, bool old = false, uint index = 0)
     {
         tieStream = file.sh;
@@ -69,6 +76,8 @@ public class Tie : IDisposable
             var inddata = new byte[maxIndEnd];
             verticesFile.sh.Read(inddata);
             indicesBuffer = new StreamHelper(new MemoryStream(inddata), tieStream._endianness);
+
+            LightmapUVs = ReadLightmapUVsRaw(verticesFile, vertSec.offset, metadataOld.Value);
         }
         else
         {
@@ -107,6 +116,52 @@ public class Tie : IDisposable
 
             Name = tieStream.ReadString(metadataNew!.Value.nameOffset);
         }
+    }
+
+    /// <summary>Reads the tie's lightmap UV array from the shared vertex blob, or returns null if
+    /// this tie doesn't have one there.
+    ///
+    /// The array is one <see cref="TieLightmapUV"/> per vertex, packed immediately after the tie's
+    /// own vertex block — metadata 0x18 is the block's END offset, so it doubles as this array's
+    /// start, and a mesh's own window begins at 0x18 + TieMesh.verticesIndex * 4.
+    ///
+    /// RETURNED RAW AND UNVALIDATED, deliberately. Validation is PER MESH and lives in
+    /// TieReader.SliceLightmapUVs, because baked lighting is a per-mesh decision: on metropolis only
+    /// 61 of 193 ties have a usable array for every one of their meshes, but 2082 of 3771 MESHES do,
+    /// spread over 173 ties. Gating the whole tie on "every vertex decodes in [0,1]" — which is what
+    /// this method used to do — threw away 112 ties that are partly baked, some of them carrying the
+    /// level's largest 256x256 lightmaps. A tie is not lit or unlit; its meshes are.
+    ///
+    /// Where a mesh's window is not real UV data it is usually zeros (an unshaded mesh's slot) or
+    /// unrelated bytes, and the per-mesh range check rejects the latter. Measured on the windows that
+    /// pass: area correlation (see TieLightmapUV) has median 0.870 over 701 scorable meshes with 490
+    /// above 0.70 — the same range as the ties that were already working.</summary>
+    private static float[]? ReadLightmapUVsRaw(IGFile verticesFile, uint sectionOffset, in TieMetadataOld meta)
+    {
+        long span = (long)meta.verticesBufferSize - meta.verticesBufferStart;
+        if (span <= 0 || span % VertexFormat0.Size != 0) return null;
+
+        int vertexCount = (int)(span / VertexFormat0.Size);
+        long start = sectionOffset + meta.verticesBufferSize;
+        if (start + (long)vertexCount * TieLightmapUV.Size > verticesFile.sh.BaseStream.Length) return null;
+
+        float[] uvs;
+        try
+        {
+            uvs = TieLightmapUV.ReadArray(verticesFile.sh, (uint)start, vertexCount);
+        }
+        catch (EndOfStreamException)
+        {
+            return null;
+        }
+
+        // NO V FLIP, and this is settled by trying it: flipping V here was tested in the running
+        // app and looked worse, so it is gone. That matches the file evidence — the game's vertex
+        // program passes location 4 into tc0.zw completely untransformed (see TieLightmapUV), so
+        // these bytes are already in the sampler's convention. If tie bakes ever look vertically
+        // wrong again, the cause is downstream (the shared lightmap sampling path that UFrags also
+        // use), not here; flipping in this method would only desynchronise ties from terrain.
+        return uvs;
     }
 
     public byte[] ToBytes(params object[]? args) => isOld ? metadataOld!.Value.ToBytes(isOld, args) : metadataNew!.Value.ToBytes(isOld, args);

--- a/ReLunacy.Engine/Loading/Objects/TieMetadata.cs
+++ b/ReLunacy.Engine/Loading/Objects/TieMetadata.cs
@@ -16,7 +16,26 @@ public record struct TieMetadataOld : ILunaObject, ILunaSerializable
     [FileOffset(0x0F)] public byte meshesCount;
     [FileOffset(0x10)] public uint Unk2;
     [FileOffset(0x14)] public uint verticesBufferStart;
+    /// <summary>Despite the name, this is the vertex block's END offset, not its size — both
+    /// relative to section 0x9000's start, same basis as <see cref="verticesBufferStart"/>.
+    /// Measured on metropolis: 0x18-0x14 is exactly vertexCount*20 for 186 of 193 ties (and is
+    /// divisible by 20 for all 193), while 0x18 alone equals vertexCount*20 for 0 of 193. So the
+    /// tie's vertex count is (0x18-0x14)/20, and 0x18 is where its vertex data stops.
+    /// Tie.cs reads this as a length and pulls that many bytes from verticesBufferStart, which
+    /// over-reads by verticesBufferStart bytes. Harmless — meshes index in by vertex, so nothing
+    /// downstream sees the surplus — but it is not what the field means.
+    /// This offset also matters for baked lighting: for 61 of the 193 ties the lightmap UV array
+    /// begins exactly here, which is what Tie.TryReadLightmapUVs reads. See
+    /// Loading.Vertices.TieLightmapUV for the proof, and for the searched-and-not-found result on
+    /// the other 132.</summary>
     [FileOffset(0x18)] public uint verticesBufferSize;
+    /// <summary>Not an offset — a FLOAT (observed 4992.0, 504.0, 752.0 on metropolis; read as a
+    /// uint these are 0x459C0000 / 0x43FC0000 / 0x443C0000). Insomniac's own post-mortem for this
+    /// game (dev/Ratchet_and_Clank_WWS_Debrief_Feb_08.pdf, "Shader Usage Controls") lists per-use
+    /// knobs that are exactly this shape: transition distance for discrete LOD, for fade-out LOD,
+    /// for shader LOD, and the detail-map fade distance. A world-space distance in the hundreds to
+    /// low thousands fits any of them. CANDIDATE ONLY — nothing has tied this value to observed LOD
+    /// behaviour yet, and there are four knobs it could be.</summary>
     [FileOffset(0x1C)] public uint Unk3;
     [FileOffset(0x20)] public Vector3 scale;
     [FileOffset(0x64)] public uint nameOffset;

--- a/ReLunacy.Engine/Loading/Objects/UFragMetadata.cs
+++ b/ReLunacy.Engine/Loading/Objects/UFragMetadata.cs
@@ -66,13 +66,22 @@ public struct UFragMetadata : ILunaSerializable
             // real alpha channel, so the "alpha = monochrome specular light" reading is genuinely
             // populated for terrain.
             lightmapIndex = sh.ReadUInt16(recordBase + 0x4E);
+            // Placement anchor, fixed-point x256 — ZoneReader divides. (0x6C, the float that would
+            // follow it, is NaN on every UFrag in metropolis, so this is a Vector3 field and not a
+            // sphere; reading a radius there is what forced the old 2.5f fallback.)
             sh.Seek(recordBase + 0x60);
             position = new Vector3(sh.ReadSingle(), sh.ReadSingle(), sh.ReadSingle());
-            sh.Seek(recordBase + 0x60);
+            // REAL bounding sphere: centre at 0x30 and radius at 0x3C, both plain world-space
+            // floats needing no x256 decode. Verified against each UFrag's own decoded vertices on
+            // metropolis (all 1987): the radius at 0x3C matches the sphere those vertices actually
+            // describe to a median relative error of 0.0001, with 99.7% inside 10%, it is never
+            // negative, and it spans 0.303..89.194 — so the 2.5f constant this replaces was wrong
+            // for essentially every UFrag and made frustum culling drop large terrain chunks early.
+            // The centre agrees with the anchor above to a median of 0.0025 world units (the two
+            // describe the same point; 0x30 just carries full float precision instead of 1/256).
+            sh.Seek(recordBase + 0x30);
             boundingSphere = new Vector4(sh.ReadSingle(), sh.ReadSingle(), sh.ReadSingle(), sh.ReadSingle());
             Unk4 = sh.ReadFromOffset(0x14, recordBase + 0x6C);
-            // Old engine's real grid anchor hasn't been located yet — fall back to the
-            // bounding-sphere position, same as before this field existed.
             newEnginePos = position;
             Unk3b = [];
         }

--- a/ReLunacy.Engine/Loading/Readers/MaterialReader.cs
+++ b/ReLunacy.Engine/Loading/Readers/MaterialReader.cs
@@ -167,8 +167,28 @@ public sealed class MaterialReader
         }
     }
 
+    /// <summary>Old engine has NO alpha-clip threshold — it cuts at zero. ShaderMetadataOld's 0x20
+    /// is not this field, and using it as one wrecked every cutout surface in the game.
+    ///
+    /// Cross-tabbed 0x20 against the renderingMode byte over metropolis's 631 old-engine shaders:
+    ///     Cutout     14 shaders, alphaClip = 1.0 on ALL FOURTEEN, no exceptions
+    ///     Opaque    426 at 1.0, 44 at a fraction (0.64, 0.80, 0.878, 0.902, ...)
+    ///     SoftEdge   28 at 1.0, 14 at 0.0
+    /// A clip threshold cannot be 1.0 on every single material that clips — that discards all but
+    /// perfectly opaque texels — and the fractional values land on OPAQUE materials, where a
+    /// threshold means nothing at all. Whatever 0x20 is (per-material opacity is the standing
+    /// suspicion, previously retracted for other reasons — see UsesVertexAlphaCandidate), it is
+    /// not this. Old engine therefore gets a zero threshold and the shader discards on `&lt;=`.
+    ///
+    /// This is also the whole of the "blocky cutout edges" problem. Every one of those 14 Cutout
+    /// materials is DXT5, which stores alpha as two endpoints interpolated across a 4x4 block, so
+    /// demanding alpha == 1.0 exactly kept only the texels sitting at an endpoint — a mask aligned
+    /// to compression blocks. The edges were the DXT5 block grid, not a filtering artifact.
+    ///
+    /// New engine keeps reading its own field at 0x30; it has not been shown to have the same
+    /// problem, and inventing a zero there would be an unforced change.</summary>
     private static float GetAlphaClip(Shader shader) =>
-        shader.isOld ? shader.metadataOld!.Value.alphaClip : shader.metadataNew!.Value.alphaClip;
+        shader.isOld ? 0f : shader.metadataNew!.Value.alphaClip;
 
     // ShaderMetadataOld 0x50/0x54, feeding the captured game shader's height * scale + bias.
     // Returned verbatim, sign included: which way relief appears to move is data, not something to

--- a/ReLunacy.Engine/Loading/Readers/TieReader.cs
+++ b/ReLunacy.Engine/Loading/Readers/TieReader.cs
@@ -85,15 +85,33 @@ public sealed class TieReader
 
         var scaleVec = legacyTie.Scale;
         var meshes = new List<IMesh>();
+
+        // Validate the lightmap UVs mesh by mesh (see SliceLightmapUVs) and rebuild the tie-wide
+        // array from only the windows that pass, so ITie.GetLightmapUVs stays consistent with what
+        // the meshes actually got. Meshes without a usable window keep zeros there — the same thing
+        // an unshaded mesh's slot holds in the file — and null means no mesh had one at all, which
+        // is what EntityTie tests before binding a bake.
+        float[]? tieLightmapUVs = null;
         for (int i = 0; i < legacyTie.MeshesCount; i++)
         {
-            meshes.Add(ConvertTieMesh(legacyTie.Meshes[i], scaleVec, legacyTie));
+            ref TieMesh m = ref legacyTie.Meshes[i];
+            var slice = SliceLightmapUVs(legacyTie.LightmapUVs, m.verticesIndex, m.verticesCount);
+            if (slice is null || !LooksLikeUnwrap(m, slice)) continue;
+
+            tieLightmapUVs ??= new float[legacyTie.LightmapUVs!.Length];
+            Array.Copy(slice, 0, tieLightmapUVs, m.verticesIndex * 2, slice.Length);
+        }
+
+        for (int i = 0; i < legacyTie.MeshesCount; i++)
+        {
+            meshes.Add(ConvertTieMesh(legacyTie.Meshes[i], scaleVec, legacyTie, tieLightmapUVs));
         }
 
         var debugName = _debugReader.GetTiePrototypeName(legacyTie.TUID);
         var name = debugName ?? (!string.IsNullOrEmpty(legacyTie.Name) ? legacyTie.Name : $"Tie_{id:X}");
 
-        return new Assets.Ties.Tie(id: id, meshes: meshes, scale: 1.0f, name: name); // per-axis scale already applied during mesh conversion
+        // per-axis scale already applied during mesh conversion
+        return new Assets.Ties.Tie(id: id, meshes: meshes, scale: 1.0f, name: name, lightmapUVs: tieLightmapUVs);
     }
 
     private void ReadTieMeshes(Objects.Tie tie)
@@ -113,16 +131,129 @@ public sealed class TieReader
         }
     }
 
-    private IMesh ConvertTieMesh(TieMesh legacyMesh, System.Numerics.Vector3 scale, Objects.Tie tie)
+    /// <summary>Rejected below this: a mesh's UV window has to actually behave like an unwrap of
+    /// THIS mesh, not merely decode in range. Measured over metropolis's 494 testable tie meshes the
+    /// score's median is 0.874, so 0.5 sits far below the real population and cuts 16% — the windows
+    /// that pass the range check by luck and would otherwise repeat the bake across the surface.</summary>
+    private const double MinUnwrapCorrelation = 0.5;
+
+    /// <summary>Below this many usable triangles the correlation is noise, so the mesh is accepted
+    /// untested rather than discarded. That covers 1329 small meshes on metropolis (34,764 vertices
+    /// total) — the remaining blind spot, and the first place to look if stray ties still show a
+    /// doubled bake.</summary>
+    private const int MinTrianglesToTest = 40;
+
+    /// <summary>Does this UV window unwrap this mesh? A lightmap packer allocates texels roughly in
+    /// proportion to world-space surface area, so per triangle log(UV area) tracks log(3D area).
+    /// Real windows score ~0.87 here; a random in-range window from elsewhere in the vertex blob
+    /// scores ~0.0, so this is the test that separates them — the [0,1] range check alone does not
+    /// (see Loading.Vertices.TieLightmapUV, which documents why several other natural metrics here
+    /// are vacuous).
+    ///
+    /// Note what this canNOT do: it does not distinguish a lightmap unwrap from an ALBEDO unwrap.
+    /// Base UVs score ~0.64 by themselves, because artists unwrap those with roughly uniform texel
+    /// density too. It only separates real-for-this-mesh from unrelated bytes, which is exactly the
+    /// failure being screened out here.
+    ///
+    /// Uses raw int16 positions: any per-axis scale is a constant factor inside the logarithm and
+    /// shifts the intercept, not the correlation.</summary>
+    private static bool LooksLikeUnwrap(in TieMesh mesh, float[] uvs)
+    {
+        var verts = mesh.vertices;
+        var indices = mesh.indices;
+        if (verts is null || indices is null) return true;
+
+        int vertexCount = mesh.verticesCount;
+        double sx = 0, sy = 0, sxx = 0, syy = 0, sxy = 0;
+        int n = 0;
+
+        for (int t = 0; t + 2 < indices.Length; t += 3)
+        {
+            int i0 = indices[t], i1 = indices[t + 1], i2 = indices[t + 2];
+            if (i0 >= vertexCount || i1 >= vertexCount || i2 >= vertexCount) return true;
+
+            var (ax, ay, az) = verts[i0].position;
+            var (bx, by, bz) = verts[i1].position;
+            var (cx, cy, cz) = verts[i2].position;
+
+            double e1x = bx - ax, e1y = by - ay, e1z = bz - az;
+            double e2x = cx - ax, e2y = cy - ay, e2z = cz - az;
+            double nx = e1y * e2z - e1z * e2y;
+            double ny = e1z * e2x - e1x * e2z;
+            double nz = e1x * e2y - e1y * e2x;
+            double area3 = 0.5 * Math.Sqrt(nx * nx + ny * ny + nz * nz);
+            if (area3 <= 1e-6) continue;
+
+            double u0 = uvs[i0 * 2], v0 = uvs[i0 * 2 + 1];
+            double du1 = uvs[i1 * 2] - u0, dv1 = uvs[i1 * 2 + 1] - v0;
+            double du2 = uvs[i2 * 2] - u0, dv2 = uvs[i2 * 2 + 1] - v0;
+            double area2 = 0.5 * Math.Abs(du1 * dv2 - du2 * dv1);
+            if (area2 <= 1e-12) continue;
+
+            double x = Math.Log(area3), y = Math.Log(area2);
+            sx += x; sy += y; sxx += x * x; syy += y * y; sxy += x * y;
+            n++;
+        }
+
+        if (n < MinTrianglesToTest) return true;
+
+        double cov = sxy - sx * sy / n;
+        double varX = sxx - sx * sx / n;
+        double varY = syy - sy * sy / n;
+        if (varX <= 0 || varY <= 0) return true;
+
+        return cov / Math.Sqrt(varX * varY) >= MinUnwrapCorrelation;
+    }
+
+    private IMesh ConvertTieMesh(TieMesh legacyMesh, System.Numerics.Vector3 scale, Objects.Tie tie, float[]? tieLightmapUVs)
     {
         legacyMesh.GetBuffers(scale, out var positions, out var indices, out var uvs, out var normals, out var tangents, out var vertexAlphaCandidates);
 
-        var geometry = new GeometryData(id: 0, positions: positions, uvs: uvs, indices: indices, normals: normals, tangents: tangents, vertexAlphaCandidates: vertexAlphaCandidates);
+        // The tie's lightmap UV array is indexed over its WHOLE vertex buffer, so each mesh takes
+        // the window starting at its own verticesIndex (see ITie.GetLightmapUVs). tieLightmapUVs is
+        // already the validated array, so this slice can't fail the range check a second time.
+        var lightmapUVs = SliceLightmapUVs(tieLightmapUVs, legacyMesh.verticesIndex, legacyMesh.verticesCount);
+
+        var geometry = new GeometryData(id: 0, positions: positions, uvs: uvs, indices: indices, normals: normals, tangents: tangents, vertexAlphaCandidates: vertexAlphaCandidates, lightmapUVs: lightmapUVs);
 
         IMaterial material = legacyMesh.isOld
             ? _materialReader.GetMaterialByIndex(legacyMesh.oldShaderIndex)
             : _materialReader.GetMaterialForLocalIndex(tie.ShaderTUIDs, legacyMesh.newShaderIndex);
 
         return new Assets.Geometry.Mesh(geometry, material, "TieMesh", TieMesh.VertexFormatName, legacyMesh.DumpVertex);
+    }
+
+    /// <summary>Copies out one mesh's window of the tie-wide lightmap UV array, or null if this mesh
+    /// has no usable one — in which case the mesh renders unlit while its siblings still light.
+    ///
+    /// THE VALIDITY CHECK IS PER MESH, and that is the whole point. Objects.Tie hands back the raw
+    /// bytes at metadata 0x18 without judging them; a mesh's window starts at verticesIndex * 4
+    /// inside that. On metropolis 2082 of 3771 tie meshes hold real UV data there but only 61 of 193
+    /// ties hold it for ALL of their meshes, so validating tie-wide discards 112 partly-baked ties —
+    /// including every tie carrying one of the level's 256x256 lightmaps. See
+    /// Loading.Vertices.TieLightmapUV.
+    ///
+    /// The test is just "every half decodes inside [0,1]". At an unknown offset that is nearly
+    /// vacuous, but at this fixed one it does the job: the windows that pass score a median 0.870 on
+    /// the area-preservation test that actually proves the decode, versus ~0.0 for matched random
+    /// windows. A short or out-of-bounds window returns null rather than a partial copy, since that
+    /// would silently shift every subsequent vertex's UV.</summary>
+    private static float[]? SliceLightmapUVs(float[]? tieLightmapUVs, ushort verticesIndex, ushort verticesCount)
+    {
+        if (tieLightmapUVs is null || verticesCount == 0) return null;
+
+        int start = verticesIndex * 2;
+        int count = verticesCount * 2;
+        if (start < 0 || start + count > tieLightmapUVs.Length) return null;
+
+        for (int i = start; i < start + count; i++)
+        {
+            float f = tieLightmapUVs[i];
+            if (!float.IsFinite(f) || f < 0f || f > 1f) return null;
+        }
+
+        var slice = new float[count];
+        Array.Copy(tieLightmapUVs, start, slice, 0, count);
+        return slice;
     }
 }

--- a/ReLunacy.Engine/Loading/Readers/ZoneReader.cs
+++ b/ReLunacy.Engine/Loading/Readers/ZoneReader.cs
@@ -165,15 +165,14 @@ public sealed class ZoneReader
         float boundingRadius;
         if (legacyUFrag.isOld)
         {
-            // Old engine's real placement anchor hasn't been located yet — position and
-            // boundingSphere share the same fixed-point ×256 field, so anchor and boundingCenter
-            // coincide here, same as before this split existed.
-            var rawCenter = new Vector3(legacyUFrag.metadata.boundingSphere.X, legacyUFrag.metadata.boundingSphere.Y, legacyUFrag.metadata.boundingSphere.Z);
-            anchor = rawCenter / 256f;
-            boundingCenter = anchor;
-            // Radius isn't reliably decodable from this field for old-engine UFrags; fixed
-            // fallback matches the last confirmed-working implementation (see EntityUFrag).
-            boundingRadius = 2.5f;
+            // Anchor comes from the fixed-point ×256 field at 0x60; the bounding sphere is its own
+            // field at 0x30/0x3C and is already world-space (see UFragMetadata, which verifies the
+            // radius against each UFrag's own vertices). These are no longer the same field, so the
+            // radius is real instead of the 2.5f constant every old UFrag used to get — that
+            // constant under-reported chunks up to 89 units across and culled them far too early.
+            anchor = legacyUFrag.metadata.position / 256f;
+            boundingCenter = new Vector3(legacyUFrag.metadata.boundingSphere.X, legacyUFrag.metadata.boundingSphere.Y, legacyUFrag.metadata.boundingSphere.Z);
+            boundingRadius = legacyUFrag.metadata.boundingSphere.W;
         }
         else
         {

--- a/ReLunacy.Engine/Loading/Shaders/Shader.cs
+++ b/ReLunacy.Engine/Loading/Shaders/Shader.cs
@@ -18,12 +18,41 @@ public class Shader
 
     public Texture? Albedo;
     public Texture? Normal;
+    // Insomniac's "expensive" map — four unrelated masks packed into one texture. Channel roles
+    // read off the captured shaders, which agree across all six programs dumped so far (one UFrag
+    // program in dev/, five tie programs in dev/ties/):
+    //   R = gloss / specular mask   multiplies the specular term
+    //   G = PARALLAX HEIGHT         fed to fma(h, parallaxScale, parallaxBias)
+    //   B = additive emissive       added to the baked light colour
+    //   A = detail-map mask         "an optional channel in the standard shader template that
+    //                               functions as a detail map mask - it modulates the intensity
+    //                               with which the detail map is applied" (WWS post-mortem)
+    // G is what pins ShaderMetadataOld.UsesParallax: in the three programs that do parallax, tex2
+    // is sampled twice (once at the raw UV for the height, once at the offset UV) and .y is read;
+    // in the three that don't, tex2 is sampled once and .y is never touched. 6/6, no exceptions.
+    // NOTE: GltfExporter.ApplyExpensiveChannels still uses the older R=spec / G=metallic /
+    // B=emissive split. R and B survive that revision; G does not.
     public Texture? Expensive;
     // Old engine only so far (ShaderMetadataOld.detailMap, offset 0x0C) — ShaderMetadataNew
-    // hasn't had its equivalent identified yet. Confirmed layout: B = roughness, R/G = a second,
-    // higher-frequency tangent-space normal map, sampled at a tiled UV. The tiling scale itself
-    // hasn't been located in ShaderMetadata's still-unidentified byte ranges — consumers
-    // (GltfExporter) use a placeholder constant until it's found.
+    // hasn't had its equivalent identified yet.
+    //
+    // Channel layout, stated outright in Insomniac's own post-mortem for this game
+    // (dev/Ratchet_and_Clank_WWS_Debrief_Feb_08.pdf, "Improved Detail Maps"): four channels, DXT5
+    // or ARGB8888, holding a colour map offset, a gloss map offset, and the two partial derivatives
+    // of a normal map delta. The captured UFrag fragment shader pins which channel is which, by
+    // where each one lands:
+    //   R = normal delta dx  ] added to the base normal map's .x/.y, scaled by fc[4].xy
+    //   G = normal delta dy  ]   (ShaderMetadataOld.detailNormalStrength)
+    //   B = COLOUR offset      added to albedo, scaled by fc[5].z (detailAlbedoStrength)
+    //   A = GLOSS offset       added to the tex2 gloss term, scaled by fc[5].w (detailSpecStrength,
+    //                          a misnomer kept only because the name is threaded through IMaterial)
+    // Both offsets are SIGNED, -1..+1 — the game gets that via the RSX texture remap, so anything
+    // decoding this map itself has to apply the same bias rather than read it as unorm.
+    // This supersedes the earlier "B = roughness, R/G = a second normal map" reading: R/G were
+    // right, but B is a colour offset and the gloss offset in A was missed entirely.
+    //
+    // Sampled at a tiled UV; the tiling scale is ShaderMetadataOld.detailTiling (0x58), with
+    // AssetManager.DefaultDetailTiling standing in only when the field reads a literal zero.
     public Texture? DetailMap;
     public RenderingMode RenderingMode => (RenderingMode)(isOld ? metadataOld!.Value.renderingMode : metadataNew!.Value.renderingMode);
 

--- a/ReLunacy.Engine/Loading/Shaders/ShaderMetadata.cs
+++ b/ReLunacy.Engine/Loading/Shaders/ShaderMetadata.cs
@@ -14,11 +14,23 @@ public record struct ShaderMetadataOld : ILunaSerializable
     [FileOffset(0x04)] public uint normal;
     [FileOffset(0x08)] public uint expensive;
     [FileOffset(0x0C)] public uint detailMap;
-    // Material feature flags. Identified from InsomniaToolset's MaterialV1_5 (shader.hpp, same
-    // section ID 0x5000), whose field layout maps onto this struct offset-for-offset: four texture
-    // references at 0x00-0x0F, this flags byte at 0x10, blendMode (our renderingMode) at 0x11.
-    // Its declared bits are, in order: unkFlag, useSpecular, useGlossiness, useNormalMap,
+    // Material feature flags. Field POSITION identified from InsomniaToolset's MaterialV1_5
+    // (shader.hpp, same section ID 0x5000), whose layout maps onto this struct offset-for-offset:
+    // four texture references at 0x00-0x0F, this flags byte at 0x10, blendMode (our renderingMode)
+    // at 0x11. Its declared bits are, in order: unkFlag, useSpecular, useGlossiness, useNormalMap,
     // useDetailMap, then 3 spare.
+    //
+    // The NAMES are Insomniac's own, and "useSpecular" is wrong. Their WWS post-mortem for this
+    // exact game (dev/Ratchet_and_Clank_WWS_Debrief_Feb_08.pdf, "Shader Usage Controls") lists the
+    // toggles they shipped as: "Which attributes (NORMAL, GLOSS, PARALLAX, DETAIL MAP) are disabled
+    // for this use of the shader." Four attributes, and specular is not among them — parallax is.
+    // Gloss, normal and detail map all line up with the other three bits, so the odd one out is the
+    // one InsomniaToolset guessed at. Hence UsesParallax below.
+    //
+    // Same source explains WHY this byte exists at all: there is ONE "standard shader template",
+    // and every material is that template with some attributes switched off. So these bits are not
+    // decoration — they are the permutation key, and a renderer that honours them reproduces the
+    // game's material variants without needing a shader per variant.
     [FileOffset(0x10)] public byte flags;
 
     // Bit positions assume the least-significant-first allocation InsomniaToolset's own (x86)
@@ -29,7 +41,10 @@ public record struct ShaderMetadataOld : ILunaSerializable
     // the decoded flags, so on any level exactly one bit will track "this material has a detail
     // texture". If UsesDetailMap disagrees with DetailMap being non-null across materials, the
     // walk is reversed and these shift to 7-minus.
-    public readonly bool UsesSpecular => (flags & 0x02) != 0;
+    // The same trick pins UsesParallax independently: this struct already carries parallaxScale at
+    // 0x50, so on any level this bit should track parallaxScale != 0. If it tracks something else,
+    // the parallax toggle is one of the other bits (unkFlag at 0x01 being the obvious alternative).
+    public readonly bool UsesParallax => (flags & 0x02) != 0;
     public readonly bool UsesGlossiness => (flags & 0x04) != 0;
     public readonly bool UsesNormalMap => (flags & 0x08) != 0;
     public readonly bool UsesDetailMap => (flags & 0x10) != 0;

--- a/ReLunacy.Engine/Loading/Vertices/TieLightmapUV.cs
+++ b/ReLunacy.Engine/Loading/Vertices/TieLightmapUV.cs
@@ -1,0 +1,198 @@
+using ReLunacy.Engine.Loading.IO;
+
+namespace ReLunacy.Engine.Loading.Vertices;
+
+/// <summary>A tie's LIGHTMAP UV channel: one pair of big-endian half floats per vertex, in its own
+/// tightly packed 4-byte-stride array OUTSIDE the 20-byte <see cref="VertexFormat0"/> record.
+///
+/// CONFIRMED BY THE GAME'S OWN VERTEX PROGRAM (dev/ties/ties_vertex_shader_LOD0.glsl). That program
+/// reads five attributes and routes them like this:
+///     location 0 -> in_pos          SINT16 x4  @+0   position.xyz, and see VertexFormat0.boneIndex
+///     location 1 -> in_weight       SFLOAT16x2 @+8   -> tc0.XY   (albedo/base UV)
+///     location 2 -> in_normal       CMP        @+12  -> tc3      (normal)
+///     location 3 -> in_diff_color   CMP        @+16  -> tc4      (TANGENT, not a colour)
+///     location 4 -> in_spec_color   THIS       stride 4, own stream
+/// and then, verbatim:
+///     r0.z = in_spec_color.xy.x;  r0.w = in_spec_color.xy.y;   dst_reg7 = r0;   tc0 = dst_reg7;
+/// so tc0.ZW IS LOCATION 4 — the exact place the tie fragment programs sample the baked light
+/// colour (tex4) and light direction (tex14). No scale, no bias, no flip is applied on the way:
+/// whatever bytes are in the file are the texture coordinates. A V flip was tried in the loader and
+/// looked worse in the app, so ties use these UVs raw — if the orientation is ever wrong again, fix
+/// it in the sampling path UFrags share, not per asset type.
+/// The names in that listing are RSX's fixed attribute-slot names (0=position, 1=weight, 2=normal,
+/// 3=diffuse colour, 4=specular colour, ...), not semantics — Insomniac repurposed slots 3 and 4.
+///
+/// This is not a second UV set bolted into VertexFormat0 — there is no room in it, and searching it
+/// is what kept failing. RPCS3's captured DrawParametersBuffer for a tie draw
+/// (dev/ties/VS_ties_set0-2-buffer.bin) describes every attribute of every draw in the frame, and
+/// the tie shape is unambiguous. Of 83,014 draws whose attribute 0 is a stride-20 SINT16 x4
+/// position (VertexFormat0's exact size and type), 81,197 bind a FIFTH attribute at location 4
+/// living in its own stream at stride 4:
+///     attr0  stride=20 offset=+0   SINT16 x4     -> VertexFormat0.position + boneIndex
+///     attr1  stride=20 offset=+8   SFLOAT16 x2   -> VertexFormat0.UVs
+///     attr2  stride=20 offset=+12  CMP 11:11:10  -> VertexFormat0 packed normal
+///     attr3  stride=20 offset=+16  CMP 11:11:10  -> VertexFormat0 packed tangent
+///     attr4  stride=4               (own stream) -> THIS
+/// attr4 is SFLOAT16 x2 on 30,015 of those draws and UBYTE x4 on the other 51,182 — mutually
+/// exclusive, same slot. THE SLOT IS POLYMORPHIC, and the reduced tie fragment programs show what
+/// the other reading is. In ties_fragment_shader_far.glsl:
+///     h1.w   = clamp16(tc0.zzzz).w;
+///     h1.xyz = clamp16(h3 * h1.wwww).xyz;            // light term SCALED by tc0.z
+/// and in ties_fragment_shader_medium_no_normal.glsl:
+///     h0.w   = clamp16(tc0.zzzz).w;
+///     h0.xyz = mix(h0.xyz, tex0.xyz, tc0.z != 0);
+///     h0.xyz = clamp16(h0 * h0.wwww).xyz;            // albedo SCALED by tc0.z
+/// tc0.z is location 4's FIRST component, so in those variants this attribute is not a texture
+/// coordinate at all — it is a per-vertex scalar multiplying the surface colour. That is the
+/// PER-VERTEX BAKED LIGHTING the WWS post-mortem budgets for ("50 MB Baked lighting data (mix of
+/// light maps and per-vertex data)"). So: half x2 here = lightmap UV pair; UNORM8 x4 here = baked
+/// per-vertex light, of which these variants consume one channel.
+/// Which one a draw gets is a per-USE decision, the same mechanism as every other knob in "Shader
+/// Usage Controls" — the full-featured program samples the baked atlases, the shader-LOD/reduced
+/// programs take the cheap per-vertex term instead.
+/// This corrects an earlier claim in this file that UNORM8 here meant "an 8-bit UV pair, not vertex
+/// colour". That is true only of the LOD0 program, which consumes .xy as a pair; it is not true of
+/// the family. Note also 0x18 is not where the UNORM8 arrays live: decoded there as a u8 UV pair the
+/// area test below gives median r = -0.099 across 163 ties against +0.899 for the half decode — but
+/// that test assumes UVs, so it says nothing about the vertex-colour reading either way.
+/// Every one of the 81,197 has frequency=1 and modulo=0, i.e. genuinely indexed per vertex, not a
+/// per-instance divisor; and swap_bytes=1, i.e. big-endian source, same as every other attribute
+/// here. Hence: 4 bytes per vertex, two big-endian halves, exactly one entry per vertex.
+///
+/// WHERE THE ARRAY LIVES — SOLVED, and the answer is per MESH, not per tie.
+/// It sits immediately after the tie's own vertex block, at TieMetadataOld's 0x18 (see that field:
+/// 0x18 is the END offset of the vertex block, not a size — 0x18-0x14 is exactly vertexCount*20 for
+/// 186/193 ties), and a mesh's own window begins at 0x18 + TieMesh.verticesIndex * 4. Nothing else
+/// is needed: fitting a constant byte delta per tie by brute force returns delta = 0.
+///
+/// The long hunt through this file's history for "the other 132 ties" was chasing a bug in the
+/// question. Baked lighting is a per-MESH property, so requiring every vertex of a tie to decode
+/// in [0,1] fails a tie as soon as ONE of its meshes is unshaded or holds something else:
+///     meshes with a valid array here          2082 / 3771
+///     ties where ALL meshes are valid           61 / 193   <- all the old code could see
+///     ties where SOME meshes are valid         112 / 193   <- discarded whole, wrongly
+///     ties where none are                       20 / 193
+/// Those 112 include every tie carrying one of metropolis's 256x256 lightmaps, the largest in the
+/// level. Over the scorable valid meshes the area test below gives median r = 0.874 — the same
+/// distribution as the ties that already worked, so this is the same data, not a weaker second tier.
+/// Validate per mesh (TieReader.SliceLightmapUVs) and the problem is gone.
+///
+/// THE RANGE CHECK ALONE IS NOT ENOUGH AT MESH GRANULARITY. Of the 2082 meshes it admits, 259 are
+/// all-zero (an unshaded mesh's slot — harmless, they sample texel 0,0 exactly as the game does) and
+/// 494 carry enough triangles to test; of those, 16% score below 0.5 on the area test. Those are
+/// windows that pass the range check by luck, and they render as the bake REPEATED across the
+/// surface, which is what "some ties show the lightmap twice" looks like. TieReader.LooksLikeUnwrap
+/// screens them. The failures cluster by tie (18 and 105 are the worst on metropolis), which is what
+/// you would expect if those ties' real arrays are somewhere else entirely rather than absent.
+/// Blind spot: 1329 admitted meshes have too few triangles to test (34,764 vertices total) and are
+/// accepted untested. If a doubled bake survives, look there first.
+///
+/// It is NOT the lightmap index. Those were checked directly: 1728 of metropolis's 4848 tie
+/// instances carry one, all 1728 distinct, no reuse, and the high 16 bits of the u32 at 0x58 are
+/// zero in all 4848. Two instances never share a bake, so a doubled-looking tie is always UVs.
+///
+/// THE TEST THAT SETTLES IT is area preservation, not range and not overlap. A lightmap unwrap
+/// allocates texels roughly in proportion to world-space surface area, so per triangle, log(UV
+/// area) tracks log(3D area). Over the tie's own indexed triangles, at 0x18:
+///     real       n=47 ties   median r = +0.899   40 of 47 above 0.70
+///     control    n=60        median r = -0.042    0 of 60 above 0.50
+/// where the control is a random 4-aligned window elsewhere in section 0x9000 of the same length
+/// that ALSO passes the range check — i.e. matched on every criterion except being this tie's data.
+/// Separation is total. (14 of the 61 are all-zero and drop out of the correlation as degenerate;
+/// they are what an unshaded tie's slot looks like. It happens per MESH too, not just per tie —
+/// tie 85 has real charts for 18% of its vertices and exact (0,0) for the rest.)
+///
+/// Two earlier numbers in this comment were retracted. "1.05 vs 292 triangles per covered texel"
+/// compared against a control that did not have to pass the range check, which made it look ~280x
+/// more decisive than it is; with a matched control the same metric gives 4.19 vs 10.72, which is
+/// suggestive at best. Do NOT use a range test on its own either: decoded as halves, section 0x9000
+/// has 60,000-200,000 four-aligned windows per length entirely inside [0,1], so "all in range" is
+/// close to vacuous at blob scale (same trap as UFragVertex.UVs2's u16 reading — see that comment).
+/// A distinct-value/quantisation test does not separate them at all.
+///
+/// THE OTHER 132 ARE NOT IN SECTION 0x9000 — searched and not found, which is worth knowing before
+/// anyone searches it again. Using the area correlation as the search score, every 4-aligned window
+/// in the blob was ranked for each tie, restricted to windows that decode fully in-range AND do not
+/// overlap any tie's declared vertex block. The search is sound: on ties whose array is known, the
+/// true offset ranks #1 out of 80,000-180,000 candidates, 10 times out of 10. Run over the 132 it
+/// returns exactly one hit above threshold, at r=0.751 against known-good ties scoring 0.74-0.97 —
+/// i.e. indistinguishable from the best of ~150,000 draws from the null distribution. Treat it as
+/// nothing found. main.dat was searched the same way for the 12 worst offenders (ties with the most
+/// lightmapped instances and no array) and is also clean: best r = 0.436 against known-good ties
+/// scoring 0.74-0.97. And there is nowhere else obvious to look — vertices.dat is exactly its two
+/// sections plus a 128-byte header, with no slack, and the level has no separate lightmap file.
+/// STILL UNTESTED, and the best remaining lead: the same search for an 8-BIT array. The shader
+/// admits UNORM8 at location 4 and the draw census splits 51,182 UBYTE against 30,015 half — the
+/// same lopsided majority as 132 ties without an array against 61 with one. Only the fixed offset
+/// 0x18 was checked as u8 (it fails); a blob-wide u8 search was attempted and abandoned, because the
+/// range prefilter that makes the half search tractable is vacuous for u8 (every byte pair is in
+/// [0,1] by construction) and the locality prefilter tried instead just selects runs of zeros.
+/// Whoever picks this up needs a prefilter that demands real spread AND vertex-to-vertex coherence.
+/// So those ties either have no baked lighting at all (consistent with the WWS
+/// post-mortem's per-use "what should have shadows" control, and with the per-mesh version of the
+/// same thing: tie 85 has real charts for 18% of its vertices and exact (0,0) for the rest), or
+/// their UVs are stored per-INSTANCE, or outside this section entirely. An earlier draft of this
+/// comment blamed an insufficient gap to the next tie; that reasoning was junk, because UFrag and
+/// moby vertices share this blob, so "the gap" was never tie-exclusive in the first place.
+///
+/// THE UV ARRAY IS PER-ASSET; THE BAKED TEXTURE IS PER-INSTANCE. These are separate questions and
+/// the answers differ, which is easy to conflate. The texture side is settled and per-instance: 1728
+/// of metropolis's 4848 tie instances carry a lightmap index, every one distinct, no reuse (see
+/// TieInstance.LightmapIndex). The UV side is per-asset, and the array at 0x18 proves it directly —
+/// the gap between a tie's vertex block and the next tie's is exactly vertexCount*4 REGARDLESS of
+/// how many instances the tie has. Tie 3 has 310 instances and still gets 4*n bytes; tie 60 has 1
+/// and gets the same. If the array were per-instance the gap would scale with the instance count,
+/// and it never does. The size accounting agrees: per-asset for all 193 ties is 3.07 MB, per
+/// lightmapped instance is 10.99 MB, and per instance outright is 25.69 MB, in a 27.85 MB section
+/// that already spends 15.36 MB on tie vertices. Only the per-asset figure fits alongside 1,987
+/// UFrags and every moby.
+/// So one unwrap is shared by every placement of a tie, and each placement gets its own baked
+/// texture painted into that shared UV space — which is exactly why ties need no atlas offset the
+/// way UFrags do, and why these UVs span the full [0,1] square.
+///
+/// WHICH TIES ARE LIT, on metropolis: 105 ties have at least one lightmapped instance but NO UV
+/// array at 0x18 — those are the ones that render unlit today and shouldn't. 48 ties have no
+/// lightmapped instance at all, and those are genuinely meant to be unlit: the WWS post-mortem's
+/// per-use "what should have shadows" control, served by shader-template variants with the lightmap
+/// inputs switched off (the captured far/medium tie programs are exactly those — they read tc0.z as
+/// a lone scalar and never sample tex4/tex14). Do not treat that second group as a bug.
+/// </summary>
+public readonly record struct TieLightmapUV
+{
+    /// <summary>Bytes per vertex — the RSX attribute's stride.</summary>
+    public const uint Size = 0x04;
+
+    public readonly Half U;
+    public readonly Half V;
+
+    public TieLightmapUV(Half u, Half v)
+    {
+        U = u;
+        V = v;
+    }
+
+    /// <summary>Reads <paramref name="vertexCount"/> consecutive pairs starting at
+    /// <paramref name="offset"/>, returning them flat as [u0, v0, u1, v1, ...] to match
+    /// IUFrag.GetLightmapUVs()'s shape.
+    ///
+    /// The offset is REQUIRED and deliberately has no default. TieMetadataOld's 0x18 is the right
+    /// answer for only 61 of 193 ties on metropolis (see the type comment), and defaulting to it
+    /// would silently decode unrelated blob bytes into plausible-looking in-range UVs for the rest —
+    /// which is worse than having no lightmap at all, because it renders instead of failing.
+    /// <paramref name="sh"/> must be positioned over section 0x9000's stream, big-endian.</summary>
+    public static float[] ReadArray(StreamHelper sh, uint offset, int vertexCount)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(vertexCount);
+
+        var uvs = new float[vertexCount * 2];
+
+        sh.Seek(offset);
+        for (int i = 0; i < vertexCount; i++)
+        {
+            uvs[i * 2 + 0] = (float)sh.ReadHalf();
+            uvs[i * 2 + 1] = (float)sh.ReadHalf();
+        }
+
+        return uvs;
+    }
+}

--- a/ReLunacy.Engine/Loading/Vertices/VertexFormat0.cs
+++ b/ReLunacy.Engine/Loading/Vertices/VertexFormat0.cs
@@ -26,6 +26,19 @@ public record struct VertexFormat0
     // level flag says to read this field as alpha instead of a real bone index (see
     // Material.UsesVertexAlphaCandidate for the current best-known gating condition) — this is
     // just the raw decode, callers decide when it's meaningful.
+    // WHAT THE GAME ACTUALLY DOES WITH THIS FIELD ON TIES, from its own vertex program
+    // (dev/ties/ties_vertex_shader_LOD0.glsl). It is read twice, and neither read is a bone index:
+    //     r3.xy = fract(abs(in_pos.wwww) * vc[1].zw) * vc[7].zw;   -> tc1.xy
+    //     r2.w  = sign(in_pos.wwww);                               -> tangent handedness
+    // The first is a UV PAIR bit-packed into one int16 and unpacked by two different scale factors
+    // plus fract() — almost certainly the detail-map coordinates, matching the tie fragment
+    // programs' `tc1.x != 0` gate. The second flips the tangent (r5 = tangent * r2.w) before the
+    // cross product that builds the binormal in tc5, i.e. it carries mirrored-UV handedness.
+    // That does not automatically retract VertexAlphaCandidate below — that decode was confirmed
+    // against user-supplied alpha 0/0.5/1.0 samples and predicted the midpoint — but the two
+    // readings are in tension and cannot both be the field's purpose on ties. A plausible
+    // reconciliation is that the observed "alpha" was really the packed value's low bits driving
+    // detail-map placement; that has NOT been tested. Do not build on either reading alone.
     public readonly float VertexAlphaCandidate => Math.Clamp((0xC000 - (ushort)boneIndex) / 127f, 0f, 1f);
 
     public VertexFormat0(StreamHelper sh)

--- a/ReLunacy.Engine/Rendering/AssetManager.cs
+++ b/ReLunacy.Engine/Rendering/AssetManager.cs
@@ -632,6 +632,7 @@ public sealed class AssetManager : IDisposable
         var normals = geometry.GetNormals();
         var tangents = geometry.GetTangents();
         var vertexAlpha = useVertexAlpha ? geometry.GetVertexAlphaCandidates() : null;
+        var lightmapUVs = geometry.GetLightmapUVs();
 
         int vertexCount = positions.Length / 3;
         var vertices = new Vertex3D[vertexCount];
@@ -646,8 +647,16 @@ public sealed class AssetManager : IDisposable
                 ? new Vector4(tangents[i * 4], tangents[i * 4 + 1], tangents[i * 4 + 2], tangents[i * 4 + 3])
                 : new Vector4(1f, 0f, 0f, 1f);
 
+            // Second UV channel is the LIGHTMAP UV set where the geometry has one (ties do; see
+            // IGeometry.GetLightmapUVs). Falling back to the base UV keeps the attribute
+            // well-defined for everything else, and is harmless because no lightmap is bound for
+            // those draws — mirrors EntityUFrag.ConvertUFragToVertices.
+            var lmUV = lightmapUVs != null && lightmapUVs.Length >= i * 2 + 2
+                ? new Vector2(lightmapUVs[i * 2], lightmapUVs[i * 2 + 1])
+                : uv;
+
             float alpha = vertexAlpha != null && i < vertexAlpha.Length ? vertexAlpha[i] : 1f;
-            vertices[i] = new Vertex3D(pos, uv, uv, n, tan, new Vector4(1f, 1f, 1f, alpha));
+            vertices[i] = new Vertex3D(pos, uv, lmUV, n, tan, new Vector4(1f, 1f, 1f, alpha));
         }
 
         return vertices;

--- a/ReLunacy.Engine/Rendering/Shaders/LitModelShaderSource.cs
+++ b/ReLunacy.Engine/Rendering/Shaders/LitModelShaderSource.cs
@@ -234,13 +234,14 @@ internal static class LitModelShaderSource
                     texelColor.a = 1.0F;
                     break;
                 case 1:
-                    // maps[0].value carries the material's own alphaClip threshold from the
-                    // game's shader metadata (see AssetManager.GetOrBuildMaterial), replacing a
-                    // hardcoded 0.99: that constant was invisible under point sampling (alpha is
-                    // mostly pure 0/255) but under bilinear filtering every softened edge texel
-                    // falls below 0.99 and gets discarded, eroding cutout foliage/decals into
-                    // sparse pixel speckle (confirmed live).
-                    if (texelColor.a < maps[0].value) {
+                    // maps[0].value carries the material's alphaClip threshold from
+                    // AssetManager.GetOrBuildMaterial. On the OLD engine that is 0 and the game
+                    // clips at zero - see MaterialReader.GetAlphaClip for why the metadata field
+                    // that used to feed this is not a threshold at all.
+                    // The comparison is <=, not <, and that matters: at a threshold of 0 a strict
+                    // < can never be true, so nothing would ever be discarded and cutout surfaces
+                    // would render as opaque quads.
+                    if (texelColor.a <= maps[0].value) {
                         discard;
                     }
                     break;

--- a/ReLunacy.Engine/Rendering/Shaders/VertexAlphaModelShaderSource.cs
+++ b/ReLunacy.Engine/Rendering/Shaders/VertexAlphaModelShaderSource.cs
@@ -71,7 +71,11 @@ internal static class VertexAlphaModelShaderSource
                     texelColor.a = 1.0F;
                     break;
                 case 1:
-                    if (texelColor.a < 0.99F) {
+                    // Same clip rule as LitModelShaderSource - read the material's own threshold
+                    // instead of the 0.99 constant that used to be here, and compare with <= so a
+                    // threshold of 0 (old engine, which clips at zero) still discards fully
+                    // transparent texels. See MaterialReader.GetAlphaClip.
+                    if (texelColor.a <= maps[0].value) {
                         discard;
                     }
                     break;

--- a/ReLunacy.Engine/Scene/EntityTie.cs
+++ b/ReLunacy.Engine/Scene/EntityTie.cs
@@ -47,39 +47,25 @@ public class EntityTie : Entity
         Model = model;
 
         _assetManager = assetManager;
-        // Deliberately NOT tieInstance.LightmapIndex yet. Tie instances really do carry a bake
-        // index (1728 distinct on metropolis), but ties have no identified lightmap UV set —
-        // VertexFormat0 holds exactly one UV pair and it TILES, so sampling an atlas with it
-        // repeats the bake many times per mesh. Terrain has UFragVertex.UVs2 and works; ties wait
-        // until their UV source turns up.
+        // Baked lighting for this placement, gated on the ASSET actually having a lightmap UV set.
+        // The instance's own index is real either way (1728 distinct on metropolis), but binding a
+        // bake to a tie whose second UV channel fell back to the base UV would tile the bake across
+        // every mesh - visibly wrong, and wrong in a way that looks like a shading bug rather than a
+        // missing offset. Ties without the UV array therefore render unlit, exactly as before.
         //
-        // And it will not turn up inside VertexFormat0, which is why searching that record kept
-        // failing. The captured RPCS3 DrawParametersBuffer covers every draw in the frame, and the
-        // 85250 draws with a 20-byte vertex record (VertexFormat0's exact size) match it for
-        // attr0/attr1/attr2 at +0/+8/+12 - position+boneIndex, UVs, packed normal - and then carry
-        // EXTRA attributes that live in their own streams. The candidate is sharply located: 33103
-        // draws in the frame bind an attribute of stride 4 holding 2 HALF FLOATS - a dedicated,
-        // tightly packed UV set outside the 20-byte record entirely - and it is at attribute
-        // LOCATION 4 in every single one of them (30197 of those are 20-byte records). That is the
-        // shape a lightmap UV channel has when it is bolted onto an existing vertex format without
-        // changing it, and a location that consistent is a convention, not a coincidence.
+        // The channel itself is settled. The game's tie vertex program (dev/ties/, and see
+        // Loading.Vertices.TieLightmapUV) routes RSX attribute location 4 - a stride-4 pair of half
+        // floats in its own stream, outside the 20-byte VertexFormat0 record - straight into tc0.zw,
+        // untransformed, which is where the tie fragment programs sample the baked light colour
+        // (tex4) and light direction (tex14). Ties and UFrags reach the bake identically; the older
+        // note here that ties must use "a different texcoord" was wrong. What differs per shader
+        // variant is only tc0's packing (the unlit tie variants read tc0.z as a lone scalar).
         //
-        // It also rules out reusing the terrain result directly. RPCS3 does manual vertex fetch, so
-        // one compiled vertex program serves any layout - meaning if ties shared terrain's program,
-        // terrain's answer (attr2 -> tc0.zw) would apply verbatim. It cannot: for 78752 of the 85250
-        // 20-byte draws, attr2 is a CMP 11:11:10 at +12, i.e. VertexFormat0's packed NORMAL, not a UV
-        // pair. Sampling an atlas with that would be meaningless, so ties reach the bake through a
-        // different program and a different texcoord.
-        // Consistent with this on the file side: TieMetadataOld's field at 0x18 (named
-        // verticesBufferSize) is really the vertex buffer's END offset, not a size - the 0x18-0x14
-        // span is divisible by 20 for 193/193 ties, so the vertex count is span/20. The gap between
-        // one tie's end and the next tie's start is divisible by 4 for 192/192, and equals exactly
-        // vertexCount*4 for 41 of them. Suggestive of a second stride-4 array packed between the
-        // vertex buffers, NOT yet proven - the ratio is inconsistent for the rest, so do not build
-        // on it until a tie drawcall's own vertex+fragment program confirms which attribute feeds
-        // the bake sampler. Ties use a different shader program than the captured terrain one, so
-        // the terrain result (attr2 -> tc0.zw) does not transfer.
-        LightmapIndex = Loading.Objects.Instances.TieInstance.NoLightmap;
+        // What is NOT settled is where that array lives for two thirds of ties - see
+        // TieLightmapUV.TryReadLightmapUVs' caller for the one location that is known.
+        LightmapIndex = BaseTie.GetLightmapUVs() is not null
+            ? tieInstance.LightmapIndex
+            : Loading.Objects.Instances.TieInstance.NoLightmap;
     }
 
     private readonly AssetManager _assetManager;

--- a/ReLunacy/Core/Frames/DockedFrames/ShaderBrowser.cs
+++ b/ReLunacy/Core/Frames/DockedFrames/ShaderBrowser.cs
@@ -272,7 +272,10 @@ public class ShaderBrowser : DockedFrame, ILevelListener
             // Comparing "Detail" here against whether DetailMap above is actually present, across
             // a few materials, is what confirms or reverses it.
             ImGui.Text($"0x10 flags: 0x{meta.flags:X2} (binary {Convert.ToString(meta.flags, 2).PadLeft(8, '0')})");
-            ImGui.Text($"     Spec:{meta.UsesSpecular} Gloss:{meta.UsesGlossiness} Normal:{meta.UsesNormalMap} Detail:{meta.UsesDetailMap}");
+            // Parallax, not specular — see ShaderMetadataOld.UsesParallax. Printed next to
+            // parallaxScale below so the two can be compared across materials, which is what
+            // confirms the bit.
+            ImGui.Text($"     Parallax:{meta.UsesParallax} Gloss:{meta.UsesGlossiness} Normal:{meta.UsesNormalMap} Detail:{meta.UsesDetailMap}");
             ImGui.Text($"0x12 Class: {meta.Class}");
             DrawHexDump("Unk1", 0x13, meta.Unk1);
             // Printed as a float as well as hex: this is the candidate slot for the detail-strength

--- a/ReLunacy/Core/Frames/DockedFrames/TexturesExplorer.cs
+++ b/ReLunacy/Core/Frames/DockedFrames/TexturesExplorer.cs
@@ -15,14 +15,23 @@ namespace ReLunacy.Core.Frames.DockedFrames;
 
 public record struct TextureObject
 {
-    public TextureObject(ITexture texture, Texture2D tex2d)
+    public TextureObject(ITexture texture, Texture2D tex2d, int index)
     {
         Texture = texture;
+        Index = index;
         TexturePtr = LunaWindow.Instance.imGuiController.GetOrCreateImGuiBinding(LunaWindow.Instance.GraphicsDevice.ResourceFactory, tex2d.DeviceTexture);
         BlissTexture = tex2d;
     }
 
     public readonly string? TextureName => Texture.Name;
+
+    /// <summary>Position in the level's texture table, counted in load order. This is the number
+    /// the file formats reference textures BY — foliage's 0xA200 record, for instance, picks its
+    /// texture with a small integer, not with a TUID or a pointer — so it stays visible even when a
+    /// debug name was recovered, since the name is what a human recognises and this is what the
+    /// data actually says.</summary>
+    public readonly int Index;
+
     public readonly ITexture Texture;
     public readonly Texture2D BlissTexture;
     public readonly ImTextureRef TexturePtr;
@@ -67,10 +76,15 @@ public class TexturesExplorer : DockedFrame, ILevelListener
     public void TransmitTextures(AssetManager assetManager)
     {
         textureObjects.Clear();
+        // The counter advances for EVERY source texture, including ones with no built Texture2D to
+        // show — skipping those would silently renumber everything after them, and the whole point
+        // of the index is that it matches the position the file formats reference.
+        int index = 0;
         foreach (var (id, tex) in assetManager.SourceTextures)
         {
             if (assetManager.BuiltTextures.TryGetValue(id, out var tex2d))
-                textureObjects.Add(new(tex, tex2d));
+                textureObjects.Add(new(tex, tex2d, index));
+            index++;
         }
 
         usedTextureIds = ComputeUsedTextureIds();
@@ -282,9 +296,15 @@ public class TexturesExplorer : DockedFrame, ILevelListener
             _ => textureObjects,
         };
 
-        return string.IsNullOrWhiteSpace(inputText)
-            ? objects
-            : objects.Where(t => (t.TextureName ?? "").Contains(inputText, StringComparison.OrdinalIgnoreCase));
+        if (string.IsNullOrWhiteSpace(inputText)) return objects;
+
+        // A bare number matches the index exactly, so typing "1" finds texture #1 rather than
+        // every name containing a 1 — that's the only way to look a texture up when all you have
+        // is the number some other structure referenced it by. Anything else searches names.
+        if (int.TryParse(inputText.Trim(), out int wantedIndex))
+            return objects.Where(t => t.Index == wantedIndex);
+
+        return objects.Where(t => (t.TextureName ?? "").Contains(inputText, StringComparison.OrdinalIgnoreCase));
     }
 
     protected override void Render(double deltaTime)
@@ -328,7 +348,15 @@ public class TexturesExplorer : DockedFrame, ILevelListener
 
                     bool isUsed = usedTextureIds.Contains(texobj.Texture.Id);
                     if (!isUsed) ImGui.PushStyleColor(ImGuiCol.Text, ImGui.GetStyle().Colors[(int)ImGuiCol.TextDisabled]);
-                    ImGui.Text(texobj.TextureName ?? $"Tex_{i}");
+                    // texobj.Index, never the loop counter: `i` walks the FILTERED list, so with a
+                    // search or usage filter active it labelled textures with whatever position
+                    // they happened to land on that frame.
+                    ImGui.Text($"#{texobj.Index}");
+                    if (texobj.TextureName is { Length: > 0 } name)
+                    {
+                        ImGui.SameLine();
+                        ImGui.TextWrapped(name.Split('/')[^1]);
+                    }
                     if (!isUsed) ImGui.PopStyleColor();
 
                     ImGui.NextColumn();
@@ -386,6 +414,7 @@ public class TexturesExplorer : DockedFrame, ILevelListener
                 }
                 ImGui.Separator();
                 ImGui.BeginGroup();
+                ImGui.Text(LM.Get("GUI_Frame_TextureExplorer_Preview_TextureIndex"));
                 ImGui.Text(LM.Get("GUI_Frame_TextureExplorer_Preview_TextureName"));
                 ImGui.Text(LM.Get("GUI_Frame_TextureExplorer_Preview_TextureCompressionType"));
                 ImGui.Text(LM.Get("GUI_Frame_TextureExplorer_Preview_TextureDimensions"));
@@ -393,7 +422,11 @@ public class TexturesExplorer : DockedFrame, ILevelListener
                 ImGui.EndGroup();
                 ImGui.SameLine();
                 ImGui.BeginGroup();
-                ImGui.Text(selection.TextureName ?? $"Tex_{selectedTexture}");
+                // Both numbers, because they answer different questions: Index is the position the
+                // file formats reference a texture by, Id is where its metadata record physically
+                // sits (the old engine uses the record's own offset in main.dat as its id).
+                ImGui.Text($"{selection.Index}  (id 0x{selection.Texture.Id:X})");
+                ImGui.Text(selection.TextureName is { Length: > 0 } n ? n : $"Tex_{selection.Index}");
                 ImGui.Text(selection.Texture.Format.ToString());
                 ImGui.Text($"{selection.Texture.Width}x{selection.Texture.Height}");
                 ImGui.Text($"{selection.BlissTexture.Images[0].Data.Length / 1000f}KB");
@@ -404,7 +437,7 @@ public class TexturesExplorer : DockedFrame, ILevelListener
                     if (!Directory.Exists(path))
                         Directory.CreateDirectory(path);
 
-                    File.WriteAllBytes(Path.Combine(path, GetExportFileName(selection.TextureName, selectedTexture) + ".raw"), selection.Texture.GetPixelData());
+                    File.WriteAllBytes(Path.Combine(path, GetExportFileName(selection.TextureName, selection.Index) + ".raw"), selection.Texture.GetPixelData());
                 }
                 ImGui.SameLine();
                 if(ImGui.Button(LM.Get("GUI_Frame_TextureExplorer_Preview_ExportPNG")))
@@ -414,7 +447,7 @@ public class TexturesExplorer : DockedFrame, ILevelListener
                         Directory.CreateDirectory(path);
 
                     var clone = (Image)selection.BlissTexture.Images[0].Clone();
-                    clone.SaveAsPng(Path.Combine(path, GetExportFileName(selection.TextureName, selectedTexture) + ".png"));
+                    clone.SaveAsPng(Path.Combine(path, GetExportFileName(selection.TextureName, selection.Index) + ".png"));
                 }
                 ImGui.Separator();
                 if (ImGui.Button(LM.Get("GUI_Frame_TextureExplorer_Preview_FindUsages")))

--- a/ReLunacy/Locales/en.json
+++ b/ReLunacy/Locales/en.json
@@ -209,6 +209,7 @@
         "GUI_Frame_TextureExplorer_Preview_TextureBufferSize": "Buffer Size",
         "GUI_Frame_TextureExplorer_Preview_TextureCompressionType": "Compression Format",
         "GUI_Frame_TextureExplorer_Preview_TextureDimensions": "Dimensions",
+        "GUI_Frame_TextureExplorer_Preview_TextureIndex": "Index",
         "GUI_Frame_TextureExplorer_Preview_TextureName": "Name",
         "GUI_Frame_TextureExplorer_Preview_TextureSizeOnDisk": "Size on Disk",
         "GUI_Frame_TextureExplorer_SearchHint": "Search among {0} textures...",


### PR DESCRIPTION
- Implemented GetLightmapUVs method in IGeometry and ITie interfaces.
- Updated GeometryData and Tie classes to handle lightmap UVs.
- Enhanced texture filtering and indexing in TextureObject.
- Validated lightmap UVs per mesh to ensure correct rendering.